### PR TITLE
Feature/Add Codelens Run

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:vscode-esbmc.verify",
+		"onLanguage:c",
+		"onLanguage:cpp",
+    "onCommand:vscode-esbmc.verify.file",
     "onCommand:vscode-esbmc.install",
     "onCommand:vscode-esbmc.update"
   ],
@@ -609,7 +611,7 @@
     ],
     "commands": [
       {
-        "command": "vscode-esbmc.verify",
+        "command": "vscode-esbmc.verify.file",
         "title": "ESBMC: Verify file"
       },
       {

--- a/src/codelens/codeLensProvider.ts
+++ b/src/codelens/codeLensProvider.ts
@@ -1,0 +1,44 @@
+
+import {
+  CodeLensProvider,
+  TextDocument,
+  CodeLens,
+  Range,
+  Command,
+  commands, Uri
+} from 'vscode'
+
+class EsbmcCodeLensProvider implements CodeLensProvider {
+  async provideCodeLenses (document: TextDocument): Promise<CodeLens[]> {
+    const c: Command = {
+      command: 'vscode-esbmc.verify',
+      title: 'ESBMC: Verify file'
+    }
+
+    const uri = Uri.file(document.uri.path.toString())
+    let result: any[] = []
+    const a = commands.executeCommand('vscode.executeDocumentSymbolProvider', uri)
+
+    a.then(function (value: any | undefined) {
+      value.forEach(function (element: any) {
+        // Functions have kind 11
+        if (element.kind === 11) {
+          const lineStart = element.location.range._start._line
+          const charStart = element.location.range._start._character
+          const lineEnd = element.location.range._end._line
+          const charEnd = element.location.range._end._character
+          const pos = new Range(lineStart, charStart, lineEnd, charEnd)
+          result = result.concat(new CodeLens(pos, c))
+        }
+      }
+      )
+    }, function (reason) {
+      console.error(reason)
+    })
+
+    await a
+    return result
+  }
+}
+
+export default EsbmcCodeLensProvider

--- a/src/codelens/codeLensProvider.ts
+++ b/src/codelens/codeLensProvider.ts
@@ -12,26 +12,8 @@ export class EsbmcCodeLensProvider implements CodeLensProvider {
     const uri = Uri.file(document.uri.path.toString())
     let result: any[] = []
     const a = commands.executeCommand('vscode.executeDocumentSymbolProvider', uri)
-
     a.then(function (value: any | undefined) {
-      value = value || []
-      value.forEach(function (element: any) {
-        // Functions have kind 11
-        if (element.kind === 11) {
-          const lineStart = element.location.range._start._line
-          const charStart = element.location.range._start._character
-          const lineEnd = element.location.range._end._line
-          const charEnd = element.location.range._end._character
-          const pos = new Range(lineStart, charStart, lineEnd, charEnd)
-          const functionName = element.name.split('(')[0]
-          const c: Command = {
-            command: 'vscode-esbmc.verify.function',
-            title: 'ESBMC: Verify function',
-            arguments: [{ bmc: { mainFunction: functionName } }]
-          }
-          result = result.concat(new CodeLens(pos, c))
-        }
-      })
+      result = parseDocSymbolsForCodeLens(value, document)
     }, function (reason) {
       console.error(reason)
     })
@@ -39,4 +21,76 @@ export class EsbmcCodeLensProvider implements CodeLensProvider {
     await a
     return result
   }
+}
+
+function parseDocSymbolsForCodeLens (value: any | undefined, document: TextDocument): any[] {
+  value = value || []
+  let result: any[] = []
+  let previousFunctionLineEnd = 0
+  value.forEach(function (element: any) {
+    // Functions have kind 11
+    if (element.kind === 11) {
+      const lineStart = element.location.range._start._line
+      const charStart = element.location.range._start._character
+      const lineEnd = element.location.range._end._line
+      const charEnd = element.location.range._end._character
+      const functionPosition = new Range(lineStart, charStart, lineEnd, charEnd)
+      const functionName = element.name.split('(')[0]
+      const commentFlags = checkForEsbmcCommentFlags(document, lineStart, previousFunctionLineEnd)
+      const flagArguments = commentFlags === undefined
+        ? [{ bmc: { mainFunction: functionName } }]
+        : [{}, `${commentFlags} --function ${functionName}`]
+      const command: Command = {
+        command: 'vscode-esbmc.verify.function',
+        title: 'ESBMC: Verify function',
+        arguments: flagArguments
+      }
+      result = result.concat(new CodeLens(functionPosition, command))
+      // Update previous ending line
+      previousFunctionLineEnd = lineEnd
+    }
+  })
+  return result
+}
+
+function checkForEsbmcCommentFlags (document: TextDocument, functionLineStart: number, previousFunctionLineEnd: number) {
+  const esbmcCommentTag = '@esbmc-verify'
+  const comment = getFunctionComment(document, functionLineStart, previousFunctionLineEnd)
+  // No comment so ignore
+  if (comment === null) {
+    return undefined
+  }
+  // Check comment for @esbmc-verify tag
+  const lines = comment.split('\n')
+  const match = lines.find(element => {
+    if (element.includes(esbmcCommentTag)) {
+      return true
+    }
+    return false
+  })
+  // If we find a matching comment flag, we return the written flags
+  if (match !== undefined) {
+    let flags = match.substring(match.indexOf(esbmcCommentTag) + esbmcCommentTag.length)
+    if (!(flags.trim() === '')) {
+      flags = flags.replace(/--function (\w*)/g, '')
+      return flags
+    }
+  }
+}
+
+/**
+ * Gets function comments from a document between two
+ * @param document
+ * @param functionLineStart
+ * @param previousFunctionLineEnd
+ */
+function getFunctionComment (document: TextDocument, functionLineStart: number, previousFunctionLineEnd: number): string | null {
+  const commentRange = new Range(previousFunctionLineEnd, 0, functionLineStart, 0)
+  const text = document.getText(commentRange)
+  const regex = /(\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+\/)|(\/\/.*)/g
+  const matches = text.match(regex)
+  if (matches === null) {
+    return null
+  }
+  return matches[0]
 }

--- a/src/codelens/codeLensProvider.ts
+++ b/src/codelens/codeLensProvider.ts
@@ -1,4 +1,3 @@
-
 import {
   CodeLensProvider,
   TextDocument,
@@ -8,18 +7,14 @@ import {
   commands, Uri
 } from 'vscode'
 
-class EsbmcCodeLensProvider implements CodeLensProvider {
+export class EsbmcCodeLensProvider implements CodeLensProvider {
   async provideCodeLenses (document: TextDocument): Promise<CodeLens[]> {
-    const c: Command = {
-      command: 'vscode-esbmc.verify',
-      title: 'ESBMC: Verify file'
-    }
-
     const uri = Uri.file(document.uri.path.toString())
     let result: any[] = []
     const a = commands.executeCommand('vscode.executeDocumentSymbolProvider', uri)
 
     a.then(function (value: any | undefined) {
+      value = value || []
       value.forEach(function (element: any) {
         // Functions have kind 11
         if (element.kind === 11) {
@@ -28,10 +23,15 @@ class EsbmcCodeLensProvider implements CodeLensProvider {
           const lineEnd = element.location.range._end._line
           const charEnd = element.location.range._end._character
           const pos = new Range(lineStart, charStart, lineEnd, charEnd)
+          const functionName = element.name.split('(')[0]
+          const c: Command = {
+            command: 'vscode-esbmc.verify.function',
+            title: 'ESBMC: Verify function',
+            arguments: [{ bmc: { mainFunction: functionName } }]
+          }
           result = result.concat(new CodeLens(pos, c))
         }
-      }
-      )
+      })
     }, function (reason) {
       console.error(reason)
     })
@@ -40,5 +40,3 @@ class EsbmcCodeLensProvider implements CodeLensProvider {
     return result
   }
 }
-
-export default EsbmcCodeLensProvider

--- a/src/codelens/registerCodeLense.ts
+++ b/src/codelens/registerCodeLense.ts
@@ -1,0 +1,14 @@
+import { languages, Disposable, DocumentSelector } from 'vscode'
+import { EsbmcCodeLensProvider } from './codeLensProvider'
+
+const selector: DocumentSelector = [
+  { language: 'c', scheme: 'file' },
+  { language: 'cpp', scheme: 'file' },
+  { language: 'sol', scheme: 'file' }
+]
+
+export function registerCodeLens (): Disposable[] {
+  return [
+    languages.registerCodeLensProvider(selector, new EsbmcCodeLensProvider())
+  ]
+}

--- a/src/commands/installation.ts
+++ b/src/commands/installation.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 import { getApi, FileDownloader } from '@microsoft/vscode-file-downloader-api'
-import { executeShellCommand, getInstalledVersion, getLatestVersion } from '../utils/versions'
+import { getInstalledVersion, getLatestVersion } from '../utils/versions'
+import { executeShellCommand } from '../utils/commands'
 import { compare } from 'compare-versions'
 
 // Only want one of this running at a time

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -1,12 +1,11 @@
 import { commands, Disposable, ExtensionContext } from 'vscode'
 import { run } from './run'
 import { install, update } from './installation'
-import { ConfigurationParser } from '../parsers/configParser'
 
-// eslint-disable-next-line require-jsdoc
 export function registerCommands (context: ExtensionContext): Disposable[] {
   return [
-    commands.registerCommand('vscode-esbmc.verify', async () => run(new ConfigurationParser())),
+    commands.registerCommand('vscode-esbmc.verify.file', async () => run()),
+    commands.registerCommand('vscode-esbmc.verify.function', async (overrides) => run(overrides)),
     commands.registerCommand('vscode-esbmc.install', async () => install(context)),
     commands.registerCommand('vscode-esbmc.update', async () => update(context))
   ]

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -5,7 +5,7 @@ import { install, update } from './installation'
 export function registerCommands (context: ExtensionContext): Disposable[] {
   return [
     commands.registerCommand('vscode-esbmc.verify.file', async () => run()),
-    commands.registerCommand('vscode-esbmc.verify.function', async (overrides) => run(overrides)),
+    commands.registerCommand('vscode-esbmc.verify.function', async (overrides, commentFlags) => run(overrides, commentFlags)),
     commands.registerCommand('vscode-esbmc.install', async () => install(context)),
     commands.registerCommand('vscode-esbmc.update', async () => update(context))
   ]

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,7 +8,7 @@ const CONFIG_PARSER: ConfigurationParser = new ConfigurationParser()
 /**
  * Takes a path and extracts the file extension.
  */
-export async function run (overides?: Configuration):Promise<void> {
+export async function run (overides?: Configuration, commentFlags?: string):Promise<void> {
   // Set overides to empty object if undefined
   overides = overides || {}
   const activeTextEditor = vscode.window.activeTextEditor
@@ -21,11 +21,16 @@ export async function run (overides?: Configuration):Promise<void> {
     }
     if (SUPPORTED_EXTENSIONS.has(fileExt!)) {
       let flags: string
-      try {
-        flags = CONFIG_PARSER.parse(overides)
-      } catch (error) {
-        vscode.window.showErrorMessage(`ESBMC: ${error}`)
-        return
+      // If comment flags have been passed, use them instead of parsing
+      if (commentFlags !== undefined) {
+        flags = commentFlags
+      } else {
+        try {
+          flags = CONFIG_PARSER.parse(overides)
+        } catch (error) {
+          vscode.window.showErrorMessage(`ESBMC: ${error}`)
+          return
+        }
       }
       const cmd = `esbmc ${currentlyOpenTabfilePath} ${flags}`
       const terminal = vscode.window.createTerminal('ESBMC')

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,12 +1,16 @@
 import * as vscode from 'vscode'
 import { ConfigurationParser } from '../parsers/configParser'
+import { Configuration } from '../@types/vscode.configuration'
 
 const SUPPORTED_EXTENSIONS = new Set(['c', 'cpp', 'sol', 'jimple'])
+const CONFIG_PARSER: ConfigurationParser = new ConfigurationParser()
 
 /**
  * Takes a path and extracts the file extension.
  */
-export async function run (configParser: ConfigurationParser):Promise<void> {
+export async function run (overides?: Configuration):Promise<void> {
+  // Set overides to empty object if undefined
+  overides = overides || {}
   const activeTextEditor = vscode.window.activeTextEditor
   if (activeTextEditor !== undefined) {
     const currentlyOpenTabfilePath = activeTextEditor.document.fileName
@@ -18,7 +22,7 @@ export async function run (configParser: ConfigurationParser):Promise<void> {
     if (SUPPORTED_EXTENSIONS.has(fileExt!)) {
       let flags: string
       try {
-        flags = configParser.parse()
+        flags = CONFIG_PARSER.parse(overides)
       } catch (error) {
         vscode.window.showErrorMessage(`ESBMC: ${error}`)
         return

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode'
+import { registerCodeLens } from './codelens/registerCodeLense'
 import { registerCommands } from './commands/registerCommands'
 
 // this method is called when your extension is activated
@@ -10,6 +11,7 @@ export function activate (context: vscode.ExtensionContext) {
   console.log('Congratulations, your extension "vscode-esbmc" is now active!')
   // Register Commands
   context.subscriptions.push(...registerCommands(context))
+  context.subscriptions.push(...registerCodeLens())
 }
 
 // this method is called when your extension is deactivated

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -1,0 +1,20 @@
+import * as cp from 'child_process'
+
+/**
+ * Executes a shell command and gets output, should only be used
+ * over integrated terminal API iff output is needed from the
+ * command call
+ *
+ * @param cmd Command to execute
+ * @returns The resolved output or error message
+ */
+export async function executeShellCommand (cmd: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    cp.exec(cmd, (err, out) => {
+      if (err) {
+        return reject(err.message)
+      }
+      return resolve(out)
+    })
+  })
+}

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -1,24 +1,5 @@
 import { Request, default as fetch } from 'node-fetch'
-import * as cp from 'child_process'
-
-/**
- * Executes a shell command and gets output, should only be used
- * over integrated terminal API iff output is needed from the
- * command call
- *
- * @param cmd Command to execute
- * @returns The resolved output or error message
- */
-export async function executeShellCommand (cmd: string): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    cp.exec(cmd, (err, out) => {
-      if (err) {
-        return reject(err.message)
-      }
-      return resolve(out)
-    })
-  })
-}
+import { executeShellCommand } from './commands'
 
 export async function getLatestVersion () {
   const request = new Request('https://github.com/esbmc/esbmc/releases/latest')


### PR DESCRIPTION
Used @rafaelsamenezes implementation of the [`EsbmcCodeLensProvider`](https://github.com/rafaelsamenezes/esbmc-vscode) and modified the `run` function to take an `overide` optional parameter which allows certain properties to be overwritten from the settings. This means all we need to do in the code lens provider is extract the method name and then override the `bmc.mainFunction` setting before it is passed to the parser. 
