### PR TITLE
Report violated properties as diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- Violated properties are reported as diagnostics: squiggles on the failing
+  line and entries in the Problems panel, read from ESBMC SARIF output rather
+  than scraped from the log.
+- `esbmc.editor.verifyOnSave` verifies a file each time it is saved, and
+  `esbmc.editor.timeout` kills a run that takes too long.
+- The verdict is shown in the status bar; clicking it opens the output.
+
+### Changed
+
+- Verification output goes to an `ESBMC` output channel instead of a terminal.
+
+### Fixed
+
+- File paths are shell-quoted, so a name containing `$(...)` no longer runs as
+  a command. This was reachable by saving a file with `verifyOnSave` enabled.
+
 ## [0.1.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The ESBMC VS Code extension allows you to:
 
 - Run ESBMC on the **current C/C++ file** directly from the editor.
 - Install (download + unpack) the **latest ESBMC** binary on Linux using a dedicated command.
-- See ESBMC results in the integrated VS Code terminal.
+- See violated properties as squiggles in the editor and in the Problems panel, with the raw ESBMC output in an `ESBMC` output channel.
 
 This document assumes you are using a Debian/Ubuntu-based distribution and the **bash** shell.
 
@@ -219,11 +219,16 @@ According to `Teste_ESBMC.txt`, this workflow was successfully tested:
    ESBMC: Verify file
    ```
 
-VS Code opens a terminal showing:
+VS Code opens an **ESBMC** output channel showing the command line and the
+full ESBMC output, and reports the verdict in the status bar. Any violated
+property also appears as a squiggle on its line and in the **Problems** panel.
 
-- the ESBMC command line,
-- verification progress,
-- and the final result.
+Two settings control this:
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| `esbmc.editor.verifyOnSave` | `false` | Verify a supported file every time it is saved |
+| `esbmc.editor.timeout` | `60` | Kill a run after this many seconds; `0` waits indefinitely |
 
 ## 12. Summary
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "onLanguage:cpp",
     "onCommand:vscode-esbmc.verify.file",
     "onCommand:vscode-esbmc.install",
-    "onCommand:vscode-esbmc.update"
+    "onCommand:vscode-esbmc.update",
+    "onCommand:vscode-esbmc.showOutput"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -629,6 +630,26 @@
             "description": "Ollama model name used for analysis and explanation."
           }
         }
+      },
+      {
+        "id": "editor",
+        "title": "Editor Integration",
+        "order": 900,
+        "properties": {
+          "esbmc.editor.verifyOnSave": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Verify a supported file with ESBMC every time it is saved",
+            "order": 1
+          },
+          "esbmc.editor.timeout": {
+            "type": "number",
+            "default": 60,
+            "markdownDescription": "Kill a verification run after this many seconds, a value of `0` lets it run to completion",
+            "order": 2,
+            "minimum": 0
+          }
+        }
       }
     ],
     "commands": [
@@ -647,6 +668,10 @@
       {
         "command": "vscode-esbmc.verify.file.withAI",
         "title": "ESBMC: Verify file with Local AI"
+      },
+      {
+        "command": "vscode-esbmc.showOutput",
+        "title": "ESBMC: Show output"
       }
     ]
   },

--- a/src/commands/aiExplain.ts
+++ b/src/commands/aiExplain.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
-import { executeShellCommand } from '../utils/commands'
+import * as os from 'os'
+import * as path from 'path'
+import { executeShellCommand, quoteShellArg, runShellCommand } from '../utils/commands'
 import { callOllama } from '../ai/ollamaClient'
 
 export async function verifyWithAI (): Promise<void> {
@@ -25,19 +27,13 @@ export async function verifyWithAI (): Promise<void> {
   try {
     await executeShellCommand('esbmc --version')
   } catch {
-    esbmcCmd = '$HOME/bin/esbmc'
+    esbmcCmd = quoteShellArg(path.join(os.homedir(), 'bin', 'esbmc'))
   }
 
-  let esbmcOutput: string
-  try {
-    esbmcOutput = await executeShellCommand(`${esbmcCmd} "${filePath}"`)
-    if (!esbmcOutput || !esbmcOutput.trim()) {
-      esbmcOutput = await executeShellCommand(`${esbmcCmd} "${filePath}" 2>&1`)
-    }
-  } catch (error: any) {
-    // ESBMC retorna código != 0 quando há violação; ainda assim o output é útil
-    esbmcOutput = String(error)
-  }
+  // ESBMC prints its verdict on stderr and exits non-zero on a violation, so
+  // both streams are kept and a non-zero exit is a result, not an error.
+  const result = await runShellCommand(`${esbmcCmd} ${quoteShellArg(filePath)}`)
+  const esbmcOutput = result.stdout + result.stderr
 
   channel.appendLine('=== ESBMC Output ===\n')
   channel.appendLine(esbmcOutput.trim())

--- a/src/commands/aiExplain.ts
+++ b/src/commands/aiExplain.ts
@@ -3,6 +3,7 @@ import * as os from 'os'
 import * as path from 'path'
 import { executeShellCommand, quoteShellArg, runShellCommand } from '../utils/commands'
 import { callOllama } from '../ai/ollamaClient'
+import { editorTimeoutSeconds } from './run'
 
 export async function verifyWithAI (): Promise<void> {
   const editor = vscode.window.activeTextEditor
@@ -24,15 +25,30 @@ export async function verifyWithAI (): Promise<void> {
 
   // Try ESBMC, fallback to $HOME/bin
   let esbmcCmd = 'esbmc'
+  let cmd: string
   try {
-    await executeShellCommand('esbmc --version')
-  } catch {
-    esbmcCmd = quoteShellArg(path.join(os.homedir(), 'bin', 'esbmc'))
+    try {
+      await executeShellCommand('esbmc --version')
+    } catch {
+      esbmcCmd = quoteShellArg(path.join(os.homedir(), 'bin', 'esbmc'))
+    }
+    cmd = `${esbmcCmd} ${quoteShellArg(filePath)}`
+  } catch (error) {
+    channel.appendLine(`ESBMC: ${String(error)}`)
+    vscode.window.showErrorMessage(`ESBMC: ${String(error)}`)
+    return
   }
 
   // ESBMC prints its verdict on stderr and exits non-zero on a violation, so
   // both streams are kept and a non-zero exit is a result, not an error.
-  const result = await runShellCommand(`${esbmcCmd} ${quoteShellArg(filePath)}`)
+  // Bounded by the same setting a normal run uses: without it a
+  // non-terminating program leaves this waiting forever.
+  const timeoutSeconds = editorTimeoutSeconds()
+  const result = await runShellCommand(cmd, { timeoutMs: timeoutSeconds * 1000 })
+  if (result.timedOut) {
+    channel.appendLine(`\n[INFO] ESBMC was killed after ${timeoutSeconds}s (esbmc.editor.timeout)\n`)
+    return
+  }
   const esbmcOutput = result.stdout + result.stderr
 
   channel.appendLine('=== ESBMC Output ===\n')

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -1,5 +1,5 @@
 import { commands, Disposable, ExtensionContext } from 'vscode'
-import { run } from './run'
+import { run, showOutput } from './run'
 import { install, update } from './installation'
 
 export function registerCommands (context: ExtensionContext): Disposable[] {
@@ -7,6 +7,7 @@ export function registerCommands (context: ExtensionContext): Disposable[] {
     commands.registerCommand('vscode-esbmc.verify.file', async () => run()),
     commands.registerCommand('vscode-esbmc.verify.function', async (overrides, commentFlags) => run(overrides, commentFlags)),
     commands.registerCommand('vscode-esbmc.install', async () => install(context)),
-    commands.registerCommand('vscode-esbmc.update', async () => update(context))
+    commands.registerCommand('vscode-esbmc.update', async () => update(context)),
+    commands.registerCommand('vscode-esbmc.showOutput', () => showOutput())
   ]
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -42,6 +42,12 @@ function diagnostics (): EsbmcDiagnostics {
   return DIAGNOSTICS
 }
 
+/** `esbmc.editor.timeout`, shared so every ESBMC run is bounded the same way. */
+export function editorTimeoutSeconds (): number {
+  const configured = vscode.workspace.getConfiguration('esbmc.editor').get<number>('timeout', 60)
+  return Number.isFinite(configured) ? Math.max(0, configured) : 60
+}
+
 export function showOutput (): void {
   output().show(true)
 }
@@ -95,8 +101,7 @@ export async function run (overides?: Configuration, commentFlags?: string, docu
   }
 
   const esbmcCmd = await resolveEsbmcCommand()
-  const configured = vscode.workspace.getConfiguration('esbmc.editor').get<number>('timeout', 60)
-  const timeoutSeconds = Number.isFinite(configured) ? Math.max(0, configured) : 60
+  const timeoutSeconds = editorTimeoutSeconds()
 
   // Supersede any run still going: its output would interleave with this one.
   const token = ++runToken
@@ -113,7 +118,17 @@ export async function run (overides?: Configuration, commentFlags?: string, docu
   const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-'))
   const report = path.join(reportDir, 'result.sarif')
   try {
-    const cmd = `${esbmcCmd} ${quoteShellArg(filePath)} ${flags} --sarif-output ${quoteShellArg(report)}`
+    let cmd: string
+    try {
+      cmd = `${esbmcCmd} ${quoteShellArg(filePath)} ${flags} --sarif-output ${quoteShellArg(report)}`
+    } catch (error) {
+      // A path cmd.exe cannot be given. Refusing is the point; say so rather
+      // than verifying whatever the rewritten path names.
+      showStatus('$(error) ESBMC: cannot run')
+      channel.appendLine(`\nESBMC: ${String(error)}`)
+      vscode.window.showErrorMessage(`ESBMC: ${String(error)}`)
+      return
+    }
     channel.appendLine(cmd)
 
     const result = await runShellCommand(cmd, {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,53 +1,171 @@
 import * as vscode from 'vscode'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
 import { ConfigurationParser } from '../parsers/configParser'
 import { Configuration } from '../@types/vscode.configuration'
-import { executeShellCommand } from '../utils/commands'
+import { executeShellCommand, quoteShellArg, runShellCommand } from '../utils/commands'
+import { parseSarif, resolveFindingPaths, EsbmcFinding } from '../parsers/sarifParser'
+import { classifyVerdict, statusText } from '../parsers/verdict'
+import { EsbmcDiagnostics } from '../diagnostics/esbmcDiagnostics'
 
 const SUPPORTED_EXTENSIONS = new Set(['c', 'cpp', 'sol', 'jimple', 'py'])
 const CONFIG_PARSER: ConfigurationParser = new ConfigurationParser()
 
-/**
- * Takes a path and extracts the file extension.
- */
-export async function run (overides?: Configuration, commentFlags?: string):Promise<void> {
-  // Set overides to empty object if undefined
-  overides = overides || {}
-  const activeTextEditor = vscode.window.activeTextEditor
-  if (activeTextEditor !== undefined) {
-    const currentlyOpenTabfilePath = activeTextEditor.document.fileName
-    const fileExt = getFileExtension(currentlyOpenTabfilePath)
-    if (fileExt === undefined) {
-      vscode.window.showErrorMessage('ESBMC: Cannot determine file type, not checking')
+let OUTPUT: vscode.OutputChannel | undefined
+let STATUS: vscode.StatusBarItem | undefined
+let DIAGNOSTICS: EsbmcDiagnostics | undefined
+let disposed = false
+
+// Only the newest run may touch the shared channel, status bar and
+// diagnostics: a save-triggered run can otherwise overwrite a manual one.
+let runToken = 0
+let killInFlight: (() => void) | undefined
+
+function output (): vscode.OutputChannel {
+  OUTPUT = OUTPUT ?? vscode.window.createOutputChannel('ESBMC')
+  return OUTPUT
+}
+
+function status (): vscode.StatusBarItem {
+  if (STATUS === undefined) {
+    STATUS = vscode.window.createStatusBarItem('esbmc.verdict', vscode.StatusBarAlignment.Left, 0)
+    STATUS.name = 'ESBMC'
+    STATUS.tooltip = 'Show the ESBMC output'
+    STATUS.command = 'vscode-esbmc.showOutput'
+  }
+  return STATUS
+}
+
+function diagnostics (): EsbmcDiagnostics {
+  DIAGNOSTICS = DIAGNOSTICS ?? new EsbmcDiagnostics()
+  return DIAGNOSTICS
+}
+
+export function showOutput (): void {
+  output().show(true)
+}
+
+export function disposeRunState (): void {
+  disposed = true
+  killInFlight?.()
+  OUTPUT?.dispose()
+  STATUS?.dispose()
+  DIAGNOSTICS?.dispose()
+  OUTPUT = undefined
+  STATUS = undefined
+  DIAGNOSTICS = undefined
+}
+
+function showStatus (text: string): void {
+  const item = status()
+  item.text = text
+  item.show()
+}
+
+export async function run (overides?: Configuration, commentFlags?: string, document?: vscode.TextDocument): Promise<void> {
+  overides = overides ?? {}
+  const target = document ?? vscode.window.activeTextEditor?.document
+  if (target === undefined) {
+    vscode.window.showErrorMessage('ESBMC: No file open, not checking')
+    return
+  }
+
+  const filePath = target.fileName
+  const fileExt = getFileExtension(filePath)
+  if (fileExt === undefined) {
+    vscode.window.showErrorMessage('ESBMC: Cannot determine file type, not checking')
+    return
+  }
+  if (!SUPPORTED_EXTENSIONS.has(fileExt)) {
+    vscode.window.showErrorMessage(`ESBMC: Currently no support for .${fileExt}, not checking`)
+    return
+  }
+
+  let flags: string
+  if (commentFlags !== undefined) {
+    flags = commentFlags
+  } else {
+    try {
+      flags = CONFIG_PARSER.parse(overides)
+    } catch (error) {
+      vscode.window.showErrorMessage(`ESBMC: ${error}`)
       return
     }
-    if (SUPPORTED_EXTENSIONS.has(fileExt!)) {
-      let flags: string
-      // If comment flags have been passed, use them instead of parsing
-      if (commentFlags !== undefined) {
-        flags = commentFlags
-      } else {
-        try {
-          flags = CONFIG_PARSER.parse(overides)
-        } catch (error) {
-          vscode.window.showErrorMessage(`ESBMC: ${error}`)
-          return
-        }
-      }
-      let esbmcCmd = 'esbmc'
-      try {
-        await executeShellCommand('esbmc --version')
-      } catch {
-        esbmcCmd = '$HOME/bin/esbmc'
-      }
-      const cmd = `${esbmcCmd} ${currentlyOpenTabfilePath} ${flags}`
-      const terminal = vscode.window.createTerminal('ESBMC')
-      terminal.show()
-      terminal.sendText(cmd)
-    } else {
-      vscode.window.showErrorMessage(`ESBMC: Currently no support for .${fileExt}, not checking`)
+  }
+
+  const esbmcCmd = await resolveEsbmcCommand()
+  const configured = vscode.workspace.getConfiguration('esbmc.editor').get<number>('timeout', 60)
+  const timeoutSeconds = Number.isFinite(configured) ? Math.max(0, configured) : 60
+
+  // Supersede any run still going: its output would interleave with this one.
+  const token = ++runToken
+  killInFlight?.()
+  if (disposed) { return }
+
+  diagnostics().clear()
+  showStatus('$(loading~spin) ESBMC: verifying')
+  const channel = output()
+  channel.clear()
+  channel.show(true)
+
+  const workingDir = path.dirname(filePath)
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-'))
+  const report = path.join(reportDir, 'result.sarif')
+  try {
+    const cmd = `${esbmcCmd} ${quoteShellArg(filePath)} ${flags} --sarif-output ${quoteShellArg(report)}`
+    channel.appendLine(cmd)
+
+    const result = await runShellCommand(cmd, {
+      timeoutMs: timeoutSeconds * 1000,
+      onStart: kill => { killInFlight = kill }
+    })
+    if (token !== runToken || disposed) { return }
+    killInFlight = undefined
+
+    channel.append(result.stdout)
+    channel.append(result.stderr)
+
+    const findings = result.timedOut ? [] : resolveFindingPaths(readFindings(report, channel), workingDir)
+    diagnostics().report(findings)
+
+    // ESBMC prints its verdict on stderr and only its version banner on stdout.
+    showStatus(statusText(classifyVerdict({
+      transcript: result.stdout + result.stderr,
+      findings,
+      timedOut: result.timedOut,
+      timeoutSeconds
+    })))
+    if (result.timedOut) {
+      channel.appendLine(`\nESBMC: killed after ${timeoutSeconds}s (esbmc.editor.timeout)`)
     }
-  } else {
-    vscode.window.showErrorMessage('ESBMC: No file open, not checking')
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true })
+  }
+}
+
+/**
+ * ESBMC is preferred from PATH, falling back to where the install command puts
+ * it. Deliberately not cached: the install command can add it mid-session.
+ */
+async function resolveEsbmcCommand (): Promise<string> {
+  try {
+    await executeShellCommand('esbmc --version')
+    return 'esbmc'
+  } catch {
+    return quoteShellArg(path.join(os.homedir(), 'bin', 'esbmc'))
+  }
+}
+
+function readFindings (report: string, channel: vscode.OutputChannel): EsbmcFinding[] {
+  if (!fs.existsSync(report)) {
+    return []
+  }
+  try {
+    return parseSarif(fs.readFileSync(report, 'utf8'))
+  } catch (error) {
+    channel.appendLine(`\nESBMC: could not read the SARIF report (${String(error)})`)
+    return []
   }
 }
 
@@ -55,9 +173,12 @@ export async function run (overides?: Configuration, commentFlags?: string):Prom
  * Takes a path and extracts the file extension.
  * @param file Full path to the file.
  */
-function getFileExtension (file:string): string | undefined {
-  const fileExt = file.split('.').pop()
-  // If there is no file extension this holds
-  if (fileExt === file) { return undefined }
-  return fileExt
+function getFileExtension (file: string): string | undefined {
+  const fileExt = path.extname(file).slice(1).toLowerCase()
+  return fileExt === '' ? undefined : fileExt
+}
+
+export function isSupported (document: vscode.TextDocument): boolean {
+  const fileExt = getFileExtension(document.fileName)
+  return fileExt !== undefined && SUPPORTED_EXTENSIONS.has(fileExt)
 }

--- a/src/diagnostics/esbmcDiagnostics.ts
+++ b/src/diagnostics/esbmcDiagnostics.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode'
+import { EsbmcFinding, FindingSeverity } from '../parsers/sarifParser'
+
+const SEVERITIES: Record<FindingSeverity, vscode.DiagnosticSeverity> = {
+  error: vscode.DiagnosticSeverity.Error,
+  warning: vscode.DiagnosticSeverity.Warning,
+  note: vscode.DiagnosticSeverity.Information
+}
+
+/**
+ * SARIF counts lines and columns from 1, VS Code from 0.
+ *
+ * ESBMC reports a line but no column, and an empty range at column 0 renders
+ * as no squiggle at all on an indented line, because VS Code only widens an
+ * empty range when a word sits at that position. So the range spans the line's
+ * text, from its first non-whitespace character to its end.
+ *
+ * @param lineText The source line, when it is available to measure.
+ */
+export function toDiagnostic (finding: EsbmcFinding, lineText?: string): vscode.Diagnostic {
+  const line = Math.max(0, finding.line - 1)
+  const indent = lineText === undefined ? 0 : lineText.length - lineText.trimStart().length
+  const start = finding.column !== undefined ? Math.max(0, finding.column - 1) : indent
+  const end = lineText === undefined ? Number.MAX_SAFE_INTEGER : Math.max(start, lineText.trimEnd().length)
+
+  const diagnostic = new vscode.Diagnostic(
+    new vscode.Range(line, start, line, end),
+    finding.cwes.length > 0 ? `${finding.message} (${finding.cwes.join(', ')})` : finding.message,
+    SEVERITIES[finding.severity]
+  )
+  diagnostic.source = 'ESBMC'
+  if (finding.ruleId !== undefined) {
+    diagnostic.code = finding.ruleId
+  }
+  return diagnostic
+}
+
+function lineTextOf (file: string, line: number): string | undefined {
+  const document = vscode.workspace.textDocuments.find(open => open.fileName === file)
+  if (document === undefined || line < 1 || line > document.lineCount) {
+    return undefined
+  }
+  return document.lineAt(line - 1).text
+}
+
+export class EsbmcDiagnostics {
+  private readonly collection: vscode.DiagnosticCollection
+
+  public constructor () {
+    this.collection = vscode.languages.createDiagnosticCollection('esbmc')
+  }
+
+  public report (findings: EsbmcFinding[]): void {
+    const byFile = new Map<string, vscode.Diagnostic[]>()
+    for (const finding of findings) {
+      const diagnostics = byFile.get(finding.file) ?? []
+      diagnostics.push(toDiagnostic(finding, lineTextOf(finding.file, finding.line)))
+      byFile.set(finding.file, diagnostics)
+    }
+    for (const [file, diagnostics] of byFile) {
+      this.collection.set(vscode.Uri.file(file), diagnostics)
+    }
+  }
+
+  /**
+   * A run's findings are the whole truth for that run, and a violation can be
+   * reported against an included header rather than the file being verified,
+   * so everything is cleared rather than just the entry file.
+   */
+  public clear (): void {
+    this.collection.clear()
+  }
+
+  public dispose (): void {
+    this.collection.dispose()
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,11 @@ import * as vscode from 'vscode'
 import { registerCodeLens } from './codelens/registerCodeLense'
 import { registerCommands } from './commands/registerCommands'
 import { verifyWithAI } from './commands/aiExplain'
+import { disposeRunState, isSupported, run } from './commands/run'
+
+// Autosave can fire every second or so, and a verification run is far from
+// free, so saves are coalesced rather than queued.
+const SAVE_DEBOUNCE_MS = 500
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -15,6 +20,27 @@ export function activate (context: vscode.ExtensionContext) {
   context.subscriptions.push(...registerCodeLens())
   const aiCommand = vscode.commands.registerCommand('vscode-esbmc.verify.file.withAI', verifyWithAI)
   context.subscriptions.push(aiCommand)
+
+  let saveTimer: ReturnType<typeof setTimeout> | undefined
+  context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(document => {
+    const enabled = vscode.workspace.getConfiguration('esbmc.editor').get<boolean>('verifyOnSave', false)
+    if (!enabled || !isSupported(document)) {
+      return
+    }
+    clearTimeout(saveTimer)
+    saveTimer = setTimeout(() => {
+      run(undefined, undefined, document).catch(error => {
+        vscode.window.showErrorMessage(`ESBMC: ${String(error)}`)
+      })
+    }, SAVE_DEBOUNCE_MS)
+  }))
+
+  context.subscriptions.push({
+    dispose: () => {
+      clearTimeout(saveTimer)
+      disposeRunState()
+    }
+  })
 }
 
 // this method is called when your extension is deactivated

--- a/src/parsers/sarifParser.ts
+++ b/src/parsers/sarifParser.ts
@@ -1,0 +1,80 @@
+import * as path from 'path'
+
+export type FindingSeverity = 'error' | 'warning' | 'note'
+
+export interface EsbmcFinding {
+  file: string
+  line: number
+  column?: number
+  message: string
+  ruleId?: string
+  severity: FindingSeverity
+  cwes: string[]
+}
+
+const SEVERITIES: Record<string, FindingSeverity> = {
+  error: 'error',
+  warning: 'warning',
+  note: 'note',
+  none: 'note'
+}
+
+function findingFrom (result: any, location: any): EsbmcFinding | undefined {
+  const physical = location?.physicalLocation
+  const file = physical?.artifactLocation?.uri
+  if (typeof file !== 'string' || file === '') {
+    return undefined
+  }
+  const message = result?.message?.text
+  if (typeof message !== 'string' || message === '') {
+    return undefined
+  }
+  return {
+    file: file.replace(/^file:\/\//, ''),
+    line: physical?.region?.startLine ?? 1,
+    column: physical?.region?.startColumn,
+    message,
+    ruleId: typeof result?.ruleId === 'string' ? result.ruleId : undefined,
+    severity: SEVERITIES[result?.level] ?? 'error',
+    cwes: (result?.taxa ?? [])
+      .filter((taxon: any) => taxon?.toolComponent?.name === 'CWE' && taxon?.id !== undefined)
+      .map((taxon: any) => `CWE-${String(taxon.id)}`)
+  }
+}
+
+/**
+ * Turns an ESBMC SARIF 2.1.0 report into the violated properties it records.
+ *
+ * ESBMC emits one result per violated property, so a report with no results
+ * means the run proved every property it checked.
+ *
+ * @throws SyntaxError if the report is not valid JSON.
+ */
+export function parseSarif (report: string): EsbmcFinding[] {
+  const sarif = JSON.parse(report)
+  const findings: EsbmcFinding[] = []
+  for (const run of sarif?.runs ?? []) {
+    for (const result of run?.results ?? []) {
+      // A result with no locations cannot be shown against source.
+      for (const location of result?.locations ?? []) {
+        const finding = findingFrom(result, location)
+        if (finding !== undefined) {
+          findings.push(finding)
+        }
+      }
+    }
+  }
+  return findings
+}
+
+/**
+ * ESBMC echoes back the path shape it was given, so a finding against an
+ * included header can be relative to where ESBMC ran. A relative path would
+ * otherwise become a diagnostic on a file that does not exist.
+ */
+export function resolveFindingPaths (findings: EsbmcFinding[], base: string): EsbmcFinding[] {
+  return findings.map(finding => ({
+    ...finding,
+    file: path.isAbsolute(finding.file) ? finding.file : path.resolve(base, finding.file)
+  }))
+}

--- a/src/parsers/verdict.ts
+++ b/src/parsers/verdict.ts
@@ -1,0 +1,53 @@
+import { EsbmcFinding } from './sarifParser'
+
+export type Verdict =
+  | { kind: 'timeout', seconds: number }
+  | { kind: 'violations', count: number }
+  | { kind: 'success' }
+  | { kind: 'failed-without-findings' }
+  | { kind: 'unknown' }
+
+export interface RunOutcome {
+  transcript: string
+  findings: EsbmcFinding[]
+  timedOut: boolean
+  timeoutSeconds: number
+}
+
+/**
+ * Decides what a run means.
+ *
+ * ESBMC prints its verdict on stderr, so `transcript` has to be both streams
+ * joined. A run can also fail with nothing to place: `--sarif-output` writes no
+ * report under `--multi-property`, so findings can be empty even on failure.
+ */
+export function classifyVerdict (outcome: RunOutcome): Verdict {
+  if (outcome.timedOut) {
+    return { kind: 'timeout', seconds: outcome.timeoutSeconds }
+  }
+  if (outcome.findings.length > 0) {
+    return { kind: 'violations', count: outcome.findings.length }
+  }
+  if (outcome.transcript.includes('VERIFICATION SUCCESSFUL')) {
+    return { kind: 'success' }
+  }
+  if (outcome.transcript.includes('VERIFICATION FAILED')) {
+    return { kind: 'failed-without-findings' }
+  }
+  return { kind: 'unknown' }
+}
+
+export function statusText (verdict: Verdict): string {
+  switch (verdict.kind) {
+    case 'timeout':
+      return `$(clock) ESBMC: timed out after ${verdict.seconds}s`
+    case 'violations':
+      return `$(error) ESBMC: ${verdict.count} propert${verdict.count === 1 ? 'y' : 'ies'} violated`
+    case 'success':
+      return '$(check) ESBMC: verified'
+    case 'failed-without-findings':
+      return '$(error) ESBMC: failed, see output'
+    case 'unknown':
+      return '$(question) ESBMC: no verdict'
+  }
+}

--- a/src/test/diagnostics/EsbmcDiagnostics.test.ts
+++ b/src/test/diagnostics/EsbmcDiagnostics.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { toDiagnostic } from '../../diagnostics/esbmcDiagnostics'
+import { EsbmcFinding } from '../../parsers/sarifParser'
+
+function finding (overrides: Partial<EsbmcFinding> = {}): EsbmcFinding {
+  return {
+    file: '/a.c',
+    line: 13,
+    message: 'array bounds violated',
+    severity: 'error',
+    cwes: [],
+    ...overrides
+  }
+}
+
+describe('toDiagnostic', () => {
+  // SARIF counts lines and columns from 1, VS Code from 0.
+  it('converts the location to a zero-based range', () => {
+    const diagnostic = toDiagnostic(finding({ line: 13, column: 5 }))
+    assert.strictEqual(diagnostic.range.start.line, 12)
+    assert.strictEqual(diagnostic.range.start.character, 4)
+  })
+
+  it('starts at the beginning of the line when ESBMC gives no column', () => {
+    assert.strictEqual(toDiagnostic(finding()).range.start.character, 0)
+  })
+
+  it('never produces a negative position', () => {
+    const diagnostic = toDiagnostic(finding({ line: 0, column: 0 }))
+    assert.strictEqual(diagnostic.range.start.line, 0)
+    assert.strictEqual(diagnostic.range.start.character, 0)
+  })
+
+  it('maps severities onto the VS Code scale', () => {
+    assert.strictEqual(toDiagnostic(finding({ severity: 'error' })).severity, vscode.DiagnosticSeverity.Error)
+    assert.strictEqual(toDiagnostic(finding({ severity: 'warning' })).severity, vscode.DiagnosticSeverity.Warning)
+    assert.strictEqual(toDiagnostic(finding({ severity: 'note' })).severity, vscode.DiagnosticSeverity.Information)
+  })
+
+  it('attributes the diagnostic to ESBMC and its property', () => {
+    const diagnostic = toDiagnostic(finding({ ruleId: 'array-bounds-violated' }))
+    assert.strictEqual(diagnostic.source, 'ESBMC')
+    assert.strictEqual(diagnostic.code, 'array-bounds-violated')
+  })
+
+  it('appends the CWEs to the message when ESBMC reports any', () => {
+    assert.strictEqual(
+      toDiagnostic(finding({ cwes: ['CWE-125', 'CWE-787'] })).message,
+      'array bounds violated (CWE-125, CWE-787)'
+    )
+    assert.strictEqual(toDiagnostic(finding()).message, 'array bounds violated')
+  })
+})

--- a/src/test/diagnostics/EsbmcDiagnostics.test.ts
+++ b/src/test/diagnostics/EsbmcDiagnostics.test.ts
@@ -32,6 +32,43 @@ describe('toDiagnostic', () => {
     assert.strictEqual(diagnostic.range.start.character, 0)
   })
 
+  // The reason lineText exists: an empty range at column 0 renders as no
+  // squiggle at all on an indented line, so the range has to span the code.
+  it('spans the code on the line when the source is available', () => {
+    const diagnostic = toDiagnostic(finding(), '    values[i] = i;')
+    assert.strictEqual(diagnostic.range.start.character, 4, 'starts at the first non-whitespace character')
+    assert.strictEqual(diagnostic.range.end.character, 18, 'ends at the last')
+  })
+
+  it('stops at the end of the code, not the end of the trailing whitespace', () => {
+    const diagnostic = toDiagnostic(finding(), '  x = 1;   ')
+    assert.strictEqual(diagnostic.range.start.character, 2)
+    assert.strictEqual(diagnostic.range.end.character, 8)
+  })
+
+  // ESBMC gives no column, but a comment-flag override or another producer can.
+  it('keeps a reported column as the start, and never ends before it', () => {
+    const withColumn = toDiagnostic(finding({ column: 7 }), '    values[i] = i;')
+    assert.strictEqual(withColumn.range.start.character, 6)
+
+    const pastTheEnd = toDiagnostic(finding({ column: 40 }), '  x = 1;')
+    assert.ok(
+      pastTheEnd.range.end.character >= pastTheEnd.range.start.character,
+      'the range ends before it starts'
+    )
+  })
+
+  it('spans a blank line without inverting the range', () => {
+    const diagnostic = toDiagnostic(finding(), '    ')
+    assert.strictEqual(diagnostic.range.start.character, 4)
+    assert.strictEqual(diagnostic.range.end.character, 4)
+  })
+
+  // Without the source, the range runs to the end of whatever is there.
+  it('runs to the end of the line when the source is not available', () => {
+    assert.strictEqual(toDiagnostic(finding()).range.end.character, Number.MAX_SAFE_INTEGER)
+  })
+
   it('maps severities onto the VS Code scale', () => {
     assert.strictEqual(toDiagnostic(finding({ severity: 'error' })).severity, vscode.DiagnosticSeverity.Error)
     assert.strictEqual(toDiagnostic(finding({ severity: 'warning' })).severity, vscode.DiagnosticSeverity.Warning)

--- a/src/test/fixtures/violation.sarif
+++ b/src/test/fixtures/violation.sarif
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "/src/fails.c"
+                },
+                "region": {
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "array bounds violated: array `values' upper bound"
+          },
+          "ruleId": "array-bounds-violated",
+          "taxa": [
+            {
+              "id": "121",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            },
+            {
+              "id": "125",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            },
+            {
+              "id": "129",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            },
+            {
+              "id": "131",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            },
+            {
+              "id": "193",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            },
+            {
+              "id": "787",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            }
+          ]
+        }
+      ],
+      "taxonomies": [
+        {
+          "informationUri": "https://cwe.mitre.org/",
+          "name": "CWE",
+          "organization": "MITRE",
+          "shortDescription": {
+            "text": "Common Weakness Enumeration"
+          },
+          "taxa": [
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/121.html",
+              "id": "121",
+              "shortDescription": {
+                "text": "Stack-based Buffer Overflow"
+              }
+            },
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/125.html",
+              "id": "125",
+              "shortDescription": {
+                "text": "Out-of-bounds Read"
+              }
+            },
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/129.html",
+              "id": "129",
+              "shortDescription": {
+                "text": "Improper Validation of Array Index"
+              }
+            },
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/131.html",
+              "id": "131",
+              "shortDescription": {
+                "text": "Incorrect Calculation of Buffer Size"
+              }
+            },
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/193.html",
+              "id": "193",
+              "shortDescription": {
+                "text": "Off-by-one Error"
+              }
+            },
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/787.html",
+              "id": "787",
+              "shortDescription": {
+                "text": "Out-of-bounds Write"
+              }
+            }
+          ],
+          "version": "4.20"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://esbmc.org",
+          "name": "ESBMC",
+          "rules": [
+            {
+              "id": "array-bounds-violated",
+              "properties": {
+                "tags": [
+                  "external/cwe/cwe-121",
+                  "external/cwe/cwe-125",
+                  "external/cwe/cwe-129",
+                  "external/cwe/cwe-131",
+                  "external/cwe/cwe-193",
+                  "external/cwe/cwe-787"
+                ]
+              },
+              "shortDescription": {
+                "text": "Array bounds violated"
+              }
+            }
+          ],
+          "version": "8.4.0"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/src/test/parsers/SarifParser.test.ts
+++ b/src/test/parsers/SarifParser.test.ts
@@ -1,0 +1,131 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as path from 'path'
+import { parseSarif, resolveFindingPaths } from '../../parsers/sarifParser'
+
+const FIXTURE = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'fixtures', 'violation.sarif')
+
+// A real report from `esbmc fails.c --sarif-output`, with only the absolute
+// source path made portable.
+const violation = fs.readFileSync(FIXTURE, 'utf8')
+
+function sarif (results: unknown[]): string {
+  return JSON.stringify({ version: '2.1.0', runs: [{ results }] })
+}
+
+describe('parseSarif', () => {
+  it('reads a real ESBMC violation report', () => {
+    const findings = parseSarif(violation)
+    assert.strictEqual(findings.length, 1)
+    assert.deepStrictEqual(findings[0], {
+      file: '/src/fails.c',
+      line: 5,
+      column: undefined,
+      message: "array bounds violated: array `values' upper bound",
+      ruleId: 'array-bounds-violated',
+      severity: 'error',
+      cwes: ['CWE-121', 'CWE-125', 'CWE-129', 'CWE-131', 'CWE-193', 'CWE-787']
+    })
+  })
+
+  // ESBMC writes no report at all when everything holds, but an empty one has
+  // the same meaning: nothing was violated.
+  it('returns nothing for a report with no results', () => {
+    assert.deepStrictEqual(parseSarif(sarif([])), [])
+    assert.deepStrictEqual(parseSarif(JSON.stringify({ version: '2.1.0', runs: [] })), [])
+  })
+
+  it('reports every violated property', () => {
+    const results = [1, 2].map(line => ({
+      level: 'error',
+      message: { text: `failure ${line}` },
+      locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' }, region: { startLine: line } } }]
+    }))
+    assert.deepStrictEqual(parseSarif(sarif(results)).map(f => f.line), [1, 2])
+  })
+
+  it('keeps the column when ESBMC gives one', () => {
+    const [finding] = parseSarif(sarif([{
+      level: 'warning',
+      message: { text: 'x' },
+      locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' }, region: { startLine: 7, startColumn: 9 } } }]
+    }]))
+    assert.strictEqual(finding.line, 7)
+    assert.strictEqual(finding.column, 9)
+    assert.strictEqual(finding.severity, 'warning')
+  })
+
+  it('defaults a missing line to the top of the file', () => {
+    const [finding] = parseSarif(sarif([{
+      message: { text: 'x' },
+      locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' } } }]
+    }]))
+    assert.strictEqual(finding.line, 1)
+  })
+
+  it('treats an unknown or missing level as an error', () => {
+    for (const level of [undefined, 'none', 'nonsense']) {
+      const [finding] = parseSarif(sarif([{
+        level,
+        message: { text: 'x' },
+        locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' }, region: { startLine: 1 } } }]
+      }]))
+      assert.strictEqual(finding.severity, level === 'none' ? 'note' : 'error', `level ${String(level)}`)
+    }
+  })
+
+  it('collects CWE taxa and ignores taxonomies that are not CWE', () => {
+    const [finding] = parseSarif(sarif([{
+      message: { text: 'x' },
+      locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' }, region: { startLine: 1 } } }],
+      taxa: [
+        { id: '787', toolComponent: { name: 'CWE' } },
+        { id: 'RULE-1', toolComponent: { name: 'MISRA' } },
+        { id: '125' }
+      ]
+    }]))
+    assert.deepStrictEqual(finding.cwes, ['CWE-787'])
+  })
+
+  it('strips a file:// prefix from the location', () => {
+    const [finding] = parseSarif(sarif([{
+      message: { text: 'x' },
+      locations: [{ physicalLocation: { artifactLocation: { uri: 'file:///a.c' }, region: { startLine: 1 } } }]
+    }]))
+    assert.strictEqual(finding.file, '/a.c')
+  })
+
+  // A result we cannot place in a file would become a diagnostic with nowhere
+  // to go, so it is dropped rather than pinned to the wrong line.
+  it('drops results with no usable location or message', () => {
+    assert.deepStrictEqual(parseSarif(sarif([
+      { message: { text: 'no locations' } },
+      { message: { text: 'no uri' }, locations: [{ physicalLocation: { region: { startLine: 1 } } }] },
+      { locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' } } }] }
+    ])), [])
+  })
+
+  it('rejects a report that is not JSON', () => {
+    assert.throws(() => parseSarif('not json'), SyntaxError)
+  })
+})
+
+describe('resolveFindingPaths', () => {
+  it('leaves an absolute path alone', () => {
+    const [finding] = resolveFindingPaths([{ file: '/abs/a.c', line: 1, message: 'x', severity: 'error', cwes: [] }], '/base')
+    assert.strictEqual(finding.file, '/abs/a.c')
+  })
+
+  // ESBMC names an included header the way it was reached, which can be
+  // relative; VS Code would otherwise place the diagnostic on /inc/hdr.h.
+  it('resolves a relative header against the directory ESBMC ran in', () => {
+    const [finding] = resolveFindingPaths([{ file: 'inc/hdr.h', line: 1, message: 'x', severity: 'error', cwes: [] }], '/base')
+    assert.strictEqual(finding.file, path.resolve('/base', 'inc/hdr.h'))
+  })
+
+  it('keeps every other field', () => {
+    const original = { file: 'a.c', line: 4, message: 'x', severity: 'warning' as const, cwes: ['CWE-1'], ruleId: 'r' }
+    const [finding] = resolveFindingPaths([original], '/base')
+    assert.deepStrictEqual({ ...finding, file: original.file }, original)
+  })
+})

--- a/src/test/parsers/SarifPipeline.test.ts
+++ b/src/test/parsers/SarifPipeline.test.ts
@@ -1,0 +1,89 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { parseSarif } from '../../parsers/sarifParser'
+import { runShellCommand } from '../../utils/commands'
+
+const FAILS = `int main(void)
+{
+  int values[4];
+  for (int i = 0; i <= 4; i++)
+    values[i] = i;
+  return 0;
+}
+`
+
+const PASSES = `int main(void)
+{
+  int values[4];
+  for (int i = 0; i < 4; i++)
+    values[i] = i;
+  return values[0];
+}
+`
+
+async function esbmcAvailable (): Promise<boolean> {
+  return (await runShellCommand('esbmc --version')).code === 0
+}
+
+// Proves the SARIF contract against the real tool rather than a fixture.
+// Skipped where ESBMC is not installed, which includes CI.
+describe('SARIF pipeline against real ESBMC', function () {
+  this.timeout(120000)
+
+  let dir: string
+
+  before(async function () {
+    if (!await esbmcAvailable()) {
+      this.skip()
+    }
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-sarif-'))
+  })
+
+  after(() => {
+    if (dir !== undefined) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  async function verify (source: string, name: string) {
+    const file = path.join(dir, `${name}.c`)
+    const report = path.join(dir, `${name}.sarif`)
+    fs.writeFileSync(file, source)
+    const result = await runShellCommand(`esbmc "${file}" --sarif-output "${report}"`)
+    // ESBMC prints its verdict on stderr, not stdout.
+    return { file, report, transcript: result.stdout + result.stderr }
+  }
+
+  it('turns a violation into a finding on the right line', async () => {
+    const { file, report, transcript } = await verify(FAILS, 'fails')
+    assert.match(transcript, /VERIFICATION FAILED/)
+    const findings = parseSarif(fs.readFileSync(report, 'utf8'))
+    assert.strictEqual(findings.length, 1)
+    assert.strictEqual(findings[0].file, file)
+    assert.strictEqual(findings[0].line, 5, 'the out-of-bounds write is on line 5')
+    assert.strictEqual(findings[0].severity, 'error')
+    assert.match(findings[0].message, /array bounds/)
+    assert.ok(findings[0].cwes.length > 0, 'ESBMC reports CWEs for this property')
+  })
+
+  // ESBMC writes no report when nothing is violated, which is why run() treats
+  // a missing report as "no findings" rather than an error.
+  it('writes no report when every property holds', async () => {
+    const { report, transcript } = await verify(PASSES, 'passes')
+    assert.match(transcript, /VERIFICATION SUCCESSFUL/)
+    assert.strictEqual(fs.existsSync(report), false)
+  })
+
+  // run() has a "failed, see output" verdict solely because of this: with
+  // --multi-property ESBMC reports every violation but writes no SARIF at all.
+  it('writes no report under --multi-property, even on failure', async () => {
+    const file = path.join(dir, 'multi.c')
+    const report = path.join(dir, 'multi.sarif')
+    fs.writeFileSync(file, FAILS)
+    const result = await runShellCommand(`esbmc "${file}" --multi-property --sarif-output "${report}"`)
+    assert.match(result.stdout + result.stderr, /VERIFICATION FAILED/)
+    assert.strictEqual(fs.existsSync(report), false)
+  })
+})

--- a/src/test/parsers/Verdict.test.ts
+++ b/src/test/parsers/Verdict.test.ts
@@ -1,0 +1,78 @@
+import * as assert from 'assert'
+import { classifyVerdict, statusText, RunOutcome } from '../../parsers/verdict'
+import { EsbmcFinding } from '../../parsers/sarifParser'
+
+function finding (): EsbmcFinding {
+  return { file: '/a.c', line: 1, message: 'x', severity: 'error', cwes: [] }
+}
+
+function outcome (overrides: Partial<RunOutcome> = {}): RunOutcome {
+  return { transcript: '', findings: [], timedOut: false, timeoutSeconds: 60, ...overrides }
+}
+
+describe('classifyVerdict', () => {
+  it('reports a timeout ahead of anything else in the transcript', () => {
+    const verdict = classifyVerdict(outcome({
+      timedOut: true,
+      timeoutSeconds: 5,
+      transcript: 'VERIFICATION SUCCESSFUL',
+      findings: [finding()]
+    }))
+    assert.deepStrictEqual(verdict, { kind: 'timeout', seconds: 5 })
+  })
+
+  it('reports the number of violated properties', () => {
+    assert.deepStrictEqual(
+      classifyVerdict(outcome({ findings: [finding(), finding()], transcript: 'VERIFICATION FAILED' })),
+      { kind: 'violations', count: 2 }
+    )
+  })
+
+  it('reports success when nothing was violated', () => {
+    assert.deepStrictEqual(
+      classifyVerdict(outcome({ transcript: 'VERIFICATION SUCCESSFUL' })),
+      { kind: 'success' }
+    )
+  })
+
+  // ESBMC writes no SARIF report under --multi-property, so a run can fail
+  // with nothing to place against a line.
+  it('reports a failure that produced no findings', () => {
+    assert.deepStrictEqual(
+      classifyVerdict(outcome({ transcript: 'VERIFICATION FAILED' })),
+      { kind: 'failed-without-findings' }
+    )
+  })
+
+  it('reports no verdict when ESBMC never reached one', () => {
+    assert.deepStrictEqual(
+      classifyVerdict(outcome({ transcript: 'error: no such file' })),
+      { kind: 'unknown' }
+    )
+  })
+})
+
+describe('statusText', () => {
+  it('agrees with the number of properties', () => {
+    assert.match(statusText({ kind: 'violations', count: 1 }), /1 property violated/)
+    assert.match(statusText({ kind: 'violations', count: 3 }), /3 properties violated/)
+  })
+
+  it('names the timeout that fired', () => {
+    assert.match(statusText({ kind: 'timeout', seconds: 30 }), /timed out after 30s/)
+  })
+
+  it('gives every verdict its own text', () => {
+    const texts = [
+      statusText({ kind: 'success' }),
+      statusText({ kind: 'failed-without-findings' }),
+      statusText({ kind: 'unknown' }),
+      statusText({ kind: 'violations', count: 1 }),
+      statusText({ kind: 'timeout', seconds: 1 })
+    ]
+    assert.strictEqual(new Set(texts).size, texts.length)
+    for (const text of texts) {
+      assert.match(text, /^\$\([a-z~-]+\) ESBMC: /)
+    }
+  })
+})

--- a/src/test/utils/commands.test.ts
+++ b/src/test/utils/commands.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { executeShellCommand } from '../../utils/commands'
+import { executeShellCommand, runShellCommand } from '../../utils/commands'
 
 describe('executeShellCommand', () => {
   it('resolves with the command stdout', async () => {
@@ -25,5 +25,50 @@ describe('executeShellCommand', () => {
 
   it('rejects when the command does not exist', async () => {
     await assert.rejects(executeShellCommand('esbmc-no-such-executable'))
+  })
+})
+
+describe('runShellCommand', function () {
+  this.timeout(60000)
+
+  it('captures stdout and the exit code of a successful command', async () => {
+    const result = await runShellCommand('node -e "console.log(1)"')
+    assert.strictEqual(result.stdout.trim(), '1')
+    assert.strictEqual(result.code, 0)
+    assert.strictEqual(result.timedOut, false)
+  })
+
+  // ESBMC exits non-zero when it finds a violation, which is a result rather
+  // than an error, so a failing command must resolve instead of rejecting.
+  it('resolves rather than rejects when the command exits non-zero', async () => {
+    const result = await runShellCommand('node -e "console.error(7); process.exit(3)"')
+    assert.strictEqual(result.code, 3)
+    assert.match(result.stderr, /7/)
+    assert.strictEqual(result.timedOut, false)
+  })
+
+  it('kills a command that outlives the timeout', async () => {
+    const started = Date.now()
+    const result = await runShellCommand('node -e "setTimeout(() => {}, 60000)"', { timeoutMs: 500 })
+    assert.strictEqual(result.timedOut, true)
+    assert.ok(Date.now() - started < 30000, 'the timeout did not kill the command')
+  })
+
+  it('waits for a slow command when the timeout is zero', async () => {
+    const result = await runShellCommand('node -e "setTimeout(() => console.log(9), 300)"', { timeoutMs: 0 })
+    assert.strictEqual(result.timedOut, false)
+    assert.match(result.stdout, /9/)
+  })
+
+  // Decoding each chunk separately mangles a multi-byte character that
+  // straddles a chunk boundary, which ESBMC output hits on long traces.
+  it('decodes multi-byte output split across chunks', async () => {
+    const result = await runShellCommand(
+      // The leading byte makes every following 2-byte character straddle an
+      // odd offset, so one lands across a 64KB chunk boundary.
+      'node -e "process.stdout.write(String.fromCodePoint(0x78) + String.fromCodePoint(0x00e9).repeat(200000))"'
+    )
+    assert.strictEqual(result.stdout.length, 200001)
+    assert.strictEqual(result.stdout.includes(String.fromCodePoint(0xfffd)), false, 'replacement characters appeared')
   })
 })

--- a/src/test/utils/quoteShellArg.test.ts
+++ b/src/test/utils/quoteShellArg.test.ts
@@ -51,3 +51,49 @@ describe('quoteShellArg', function () {
     assert.strictEqual(result.stdout, '$(echo hi)')
   })
 })
+
+// The POSIX suite above skips on Windows, which left the branch that rewrites
+// its input as the only one with no coverage at all. These run everywhere by
+// driving the win32 branch directly.
+describe('quoteShellArg on Windows', () => {
+  const original = process.platform
+
+  function asWin32 (run: () => void) {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      run()
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  }
+
+  it('wraps a path in double quotes', () => {
+    asWin32(() => {
+      assert.strictEqual(quoteShellArg('C:\\Program Files\\a.c'), '"C:\\Program Files\\a.c"')
+    })
+  })
+
+  it('leaves a path alone but for the quotes', () => {
+    asWin32(() => {
+      for (const value of ['a.c', 'C:\\x\\y.c', 'with space.c', 'a&b.c', 'semi;colon.c', '$(id).c']) {
+        assert.strictEqual(quoteShellArg(value), `"${value}"`)
+      }
+    })
+  })
+
+  // cmd.exe expands %VAR% inside double quotes and offers no escape for it, so
+  // quoting a path containing one would name a different file.
+  it('refuses a path cmd.exe would rewrite rather than corrupting it', () => {
+    asWin32(() => {
+      assert.throws(() => quoteShellArg('C:\\100%\\a.c'), /cannot be passed a path containing %/)
+      assert.throws(() => quoteShellArg('C:\\%USERNAME%\\a.c'), /%/)
+      assert.throws(() => quoteShellArg('C:\\a"b\\c.c'), /cannot be passed a path containing "/)
+    })
+  })
+
+  it('names the path it refused', () => {
+    asWin32(() => {
+      assert.throws(() => quoteShellArg('C:\\100%\\a.c'), /C:\\100%\\a\.c/)
+    })
+  })
+})

--- a/src/test/utils/quoteShellArg.test.ts
+++ b/src/test/utils/quoteShellArg.test.ts
@@ -1,0 +1,53 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { quoteShellArg, runShellCommand } from '../../utils/commands'
+
+// Double quotes do not stop command substitution on POSIX, so a file name is
+// an injection vector wherever it reaches a shell. verifyOnSave makes that
+// reachable by saving a file in a hostile checkout.
+describe('quoteShellArg', function () {
+  this.timeout(60000)
+
+  let dir: string
+
+  before(function () {
+    if (process.platform === 'win32') {
+      this.skip()
+    }
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-quote-'))
+  })
+
+  after(() => {
+    if (dir !== undefined) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('stops command substitution in a file name', async () => {
+    const marker = path.join(dir, 'pwned')
+    const hostile = path.join(dir, `$(touch ${marker})x.c`)
+    await runShellCommand(`echo ${quoteShellArg(hostile)}`)
+    assert.strictEqual(fs.existsSync(marker), false, 'the substituted command ran')
+  })
+
+  it('stops backtick substitution in a file name', async () => {
+    const marker = path.join(dir, 'pwned-backtick')
+    const hostile = path.join(dir, '`touch ' + marker + '`x.c')
+    await runShellCommand(`echo ${quoteShellArg(hostile)}`)
+    assert.strictEqual(fs.existsSync(marker), false, 'the substituted command ran')
+  })
+
+  it('passes the value through unchanged', async () => {
+    for (const value of ['plain.c', 'with space.c', "it's.c", 'semi;colon.c', '$HOME.c', 'a&b|c.c']) {
+      const result = await runShellCommand(`printf %s ${quoteShellArg(value)}`)
+      assert.strictEqual(result.stdout, value)
+    }
+  })
+
+  it('leaves a command substitution intact as literal text', async () => {
+    const result = await runShellCommand(`printf %s ${quoteShellArg('$(echo hi)')}`)
+    assert.strictEqual(result.stdout, '$(echo hi)')
+  })
+})

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -18,3 +18,96 @@ export async function executeShellCommand (cmd: string): Promise<string> {
     })
   })
 }
+
+/**
+ * Quotes a value so a shell treats it as one literal argument.
+ *
+ * Double quotes are not enough on POSIX: `$(...)` and backticks still expand
+ * inside them, so a file named `$(rm -rf ~)x.c` would run its own command.
+ * `cmd.exe` has no such substitution, and leaves the metacharacters it does
+ * have alone inside double quotes.
+ */
+export function quoteShellArg (value: string): string {
+  if (process.platform === 'win32') {
+    return `"${value.replace(/"/g, '')}"`
+  }
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+export interface CommandResult {
+  stdout: string
+  stderr: string
+  code: number | null
+  timedOut: boolean
+}
+
+export interface RunOptions {
+  /** Kill the command after this long; 0 waits indefinitely. */
+  timeoutMs?: number
+  /** Receives a kill function as soon as the command starts. */
+  onStart?: (kill: () => void) => void
+}
+
+function killTree (pid: number | undefined): void {
+  if (pid === undefined) { return }
+  try {
+    if (process.platform === 'win32') {
+      cp.exec(`taskkill /pid ${pid} /T /F`)
+    } else {
+      process.kill(-pid, 'SIGKILL')
+    }
+  } catch {
+    // The command finished on its own between the kill being asked for and
+    // this call.
+  }
+}
+
+/**
+ * Runs a shell command to completion, capturing its output instead of
+ * rejecting on a non-zero exit. ESBMC exits non-zero when it finds a
+ * violation, which is a result rather than an error.
+ */
+export async function runShellCommand (cmd: string, options: RunOptions = {}): Promise<CommandResult> {
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? Math.max(0, options.timeoutMs as number) : 0
+  return new Promise<CommandResult>(resolve => {
+    // Detached so the shell leads its own process group: killing the shell
+    // alone leaves the command running and its pipes open, so the run never
+    // finishes.
+    const detached = process.platform !== 'win32'
+    const child = cp.spawn(cmd, { shell: true, detached })
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    let settled = false
+
+    // Decode per stream, not per chunk: a multi-byte character split across a
+    // chunk boundary would otherwise be mangled.
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+
+    const timer = timeoutMs > 0
+      ? setTimeout(() => {
+        // Defensive: clearTimeout normally wins, but a callback already queued
+        // when the command exits would otherwise signal a recycled pid.
+        if (settled) { return }
+        timedOut = true
+        killTree(child.pid)
+      }, timeoutMs)
+      : undefined
+
+    options.onStart?.(() => killTree(child.pid))
+
+    child.stdout?.on('data', chunk => { stdout += chunk })
+    child.stderr?.on('data', chunk => { stderr += chunk })
+    child.on('error', error => {
+      settled = true
+      clearTimeout(timer)
+      resolve({ stdout, stderr: stderr + String(error), code: null, timedOut })
+    })
+    child.on('close', code => {
+      settled = true
+      clearTimeout(timer)
+      resolve({ stdout, stderr, code, timedOut })
+    })
+  })
+}

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -19,17 +19,29 @@ export async function executeShellCommand (cmd: string): Promise<string> {
   })
 }
 
+/** Legal in a Windows path, and not expressible as one cmd.exe argument. */
+const UNQUOTABLE_ON_WINDOWS = /["%]/
+
 /**
  * Quotes a value so a shell treats it as one literal argument.
  *
  * Double quotes are not enough on POSIX: `$(...)` and backticks still expand
  * inside them, so a file named `$(rm -rf ~)x.c` would run its own command.
- * `cmd.exe` has no such substitution, and leaves the metacharacters it does
- * have alone inside double quotes.
+ *
+ * `cmd.exe` has no command substitution, but it does expand `%VAR%` inside
+ * double quotes, and a command line offers no escape for either `%` or `"`.
+ * Both are legal in a Windows path, so such a value is refused: quoting it
+ * anyway would run ESBMC against a different file than the one asked for.
+ *
+ * @throws when a Windows path cannot be expressed as one cmd.exe argument.
  */
 export function quoteShellArg (value: string): string {
   if (process.platform === 'win32') {
-    return `"${value.replace(/"/g, '')}"`
+    const unquotable = UNQUOTABLE_ON_WINDOWS.exec(value)
+    if (unquotable !== null) {
+      throw Error(`cmd.exe cannot be passed a path containing ${unquotable[0]}: ${value}`)
+    }
+    return `"${value}"`
   }
   return `'${value.replace(/'/g, "'\\''")}'`
 }


### PR DESCRIPTION
Verification now reads ESBMC's SARIF report (`--sarif-output`) rather than scraping the human-readable log, so each violated property becomes a squiggle on its line and an entry in the Problems panel. Raw output moves from a terminal to an `ESBMC` output channel, the verdict goes to the status bar, and two new settings — `esbmc.editor.verifyOnSave` and `esbmc.editor.timeout` — control when a run starts and when it is killed. Issue #18 asks for machine-readable output, so this shares that foundation.

The issue also asks for a configurable unwind bound; `esbmc.bmc.unwind` already exists and feeds the flag parser, so none was added. Note that `ConfigurationParser` reads only `globalValue`, so ESBMC flag settings are honoured at User scope but silently ignored in workspace settings — pre-existing, and worth its own issue.

**Security fix included.** File paths reaching the shell were wrapped in double quotes, which do not stop command substitution on POSIX: a file named `$(touch pwned)x.c` ran its own command. Verified end to end, and `verifyOnSave` would have made it reachable by a plain Ctrl+S in a hostile checkout. Paths are now shell-quoted, and there are tests that fail if the quoting regresses.

Stacked on #24 — merge that first.

Fixes #17