### PR TITLE
Install ESBMC on macOS and Windows, not just Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 
 - Verification output goes to an `ESBMC` output channel instead of a terminal.
+- Python and Solidity files now activate the extension and get the function
+  CodeLens. The CodeLens named them `py` and `sol`, which are file extensions
+  rather than VS Code language identifiers, so it never appeared for them.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Changed
 
+- The installer downloads the asset for the running platform and unpacks it
+  into the extension's storage directory instead of hard-coding the Linux
+  archive and writing to `$HOME/bin`. Windows uses PowerShell to unpack, since
+  it has no `unzip`, and the whole `bin/` directory is kept because
+  `esbmc.exe` needs the `libz3.dll` shipped beside it.
+- One resolver now decides which ESBMC runs, so the reported version and the
+  verified binary can no longer disagree. A user's own ESBMC on `PATH` wins
+  over one the extension installed.
 - Verification output goes to an `ESBMC` output channel instead of a terminal.
 - Python and Solidity files now activate the extension and get the function
   CodeLens. The CodeLens named them `py` and `sol`, which are file extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- Violated properties are reported as diagnostics: squiggles on the failing
+  line and entries in the Problems panel, read from ESBMC SARIF output rather
+  than scraped from the log.
+- `esbmc.editor.verifyOnSave` verifies a file each time it is saved, and
+  `esbmc.editor.timeout` kills a run that takes too long.
+- The verdict is shown in the status bar; clicking it opens the output.
+
+### Changed
+
+- Verification output goes to an `ESBMC` output channel instead of a terminal.
+
+### Fixed
+
+- File paths are shell-quoted, so a name containing `$(...)` no longer runs as
+  a command. This was reachable by saving a file with `verifyOnSave` enabled.
+
 ## [0.1.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The ESBMC VS Code extension allows you to:
 
 - Run ESBMC on the **current C/C++ file** directly from the editor.
 - Install (download + unpack) the **latest ESBMC** binary on Linux using a dedicated command.
-- See ESBMC results in the integrated VS Code terminal.
+- See violated properties as squiggles in the editor and in the Problems panel, with the raw ESBMC output in an `ESBMC` output channel.
 
 This document assumes you are using a Debian/Ubuntu-based distribution and the **bash** shell.
 
@@ -219,11 +219,16 @@ According to `Teste_ESBMC.txt`, this workflow was successfully tested:
    ESBMC: Verify file
    ```
 
-VS Code opens a terminal showing:
+VS Code opens an **ESBMC** output channel showing the command line and the
+full ESBMC output, and reports the verdict in the status bar. Any violated
+property also appears as a squiggle on its line and in the **Problems** panel.
 
-- the ESBMC command line,
-- verification progress,
-- and the final result.
+Two settings control this:
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| `esbmc.editor.verifyOnSave` | `false` | Verify a supported file every time it is saved |
+| `esbmc.editor.timeout` | `60` | Kill a run after this many seconds; `0` waits indefinitely |
 
 ## 12. Summary
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This README explains how to go from the extension source code to a working ESBMC
 The ESBMC VS Code extension allows you to:
 
 - Run ESBMC on the **current C, C++, Python or Solidity file** directly from the editor.
-- Install (download + unpack) the **latest ESBMC** binary on Linux using a dedicated command.
+- Install (download + unpack) the **latest ESBMC** binary on Linux, macOS or Windows using a dedicated command.
 - See violated properties as squiggles in the editor and in the Problems panel, with the raw ESBMC output in an `ESBMC` output channel.
 
 Once the extension is installed, **Help → Welcome → Get started with ESBMC**
@@ -24,7 +24,7 @@ This document assumes you are using a Debian/Ubuntu-based distribution and the *
 
 Before building and using the extension, make sure you have:
 
-- **Linux** (tested on Ubuntu-based systems).
+- **Linux**, **macOS** or **Windows**. The build instructions below were written on Ubuntu; the packaged extension runs on all three.
 - **Visual Studio Code** installed.
 - **curl** and **git** (for downloads and version control).
 - **unzip** installed on your system (required for automatic ESBMC installation).
@@ -205,7 +205,7 @@ With the extension installed and active:
    ESBMC: Update to latest version
    ````
 
-The extension will automatically download and install the latest ESBMC binary suitable for your Linux environment.
+The extension downloads the release asset for your platform (`esbmc-linux.zip`, `esbmc-macos.zip` or `esbmc-windows.zip`) and unpacks it into its own storage directory, so nothing is written to `$HOME/bin` and no `PATH` change is needed.
 
 ---
 
@@ -234,6 +234,14 @@ Two settings control this:
 | `esbmc.editor.verifyOnSave` | `false` | Verify a supported file every time it is saved |
 | `esbmc.editor.timeout` | `60` | Kill a run after this many seconds; `0` waits indefinitely |
 
+## 11.1 Running against a remote machine
+
+The extension is marked `extensionKind: ["workspace"]`, so with **Remote-SSH**,
+**WSL** or **Dev Containers** it runs where the code is rather than on the
+local UI host. ESBMC is then installed and executed on the remote machine,
+which is the supported route if you want a Linux ESBMC while working from a
+Windows or macOS desktop.
+
 ## 12. Summary
 
 By following the steps in this README, you can:
@@ -255,7 +263,7 @@ This feature is optional — you can continue using ESBMC normally without AI.
 
 ### Requirements for AI usage
 
-- Linux (tested on Ubuntu)
+- Linux (tested on Ubuntu), macOS and Windows
 - ESBMC installed through this extension
 - Ollama installed and running
 - A local AI model downloaded (recommended below)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This README explains how to go from the extension source code to a working ESBMC
 
 The ESBMC VS Code extension allows you to:
 
-- Run ESBMC on the **current C/C++ file** directly from the editor.
+- Run ESBMC on the **current C, C++, Python or Solidity file** directly from the editor.
 - Install (download + unpack) the **latest ESBMC** binary on Linux using a dedicated command.
 - See violated properties as squiggles in the editor and in the Problems panel, with the raw ESBMC output in an `ESBMC` output channel.
 
@@ -211,11 +211,11 @@ The extension will automatically download and install the latest ESBMC binary su
 
 ## 10. Step 8 – Using the extension
 
-### 10.1 Verify a C/C++ file
+### 10.1 Verify a file
 
 According to `Teste_ESBMC.txt`, this workflow was successfully tested:
 
-1. Open a C or C++ source file in VS Code.
+1. Open a C, C++, Python or Solidity source file in VS Code.
 2. Open the **Command Palette** (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>).
 3. Run:
 
@@ -242,7 +242,7 @@ By following the steps in this README, you can:
 2. Install dependencies and compile the ESBMC VS Code extension (`npm install`, `npm run compile`).
 3. Package the extension as a `.vsix` file with `vsce package`.
 4. Install the `.vsix` into Visual Studio Code.
-5. Use the extension to install ESBMC and verify C/C++ programs, either at the file level or per function.
+5. Use the extension to install ESBMC and verify C, C++, Python and Solidity programs, either at the file level or per function.
 
 ## 13. (Optional) Local AI Integration with Ollama
 
@@ -313,7 +313,7 @@ To install it:
 
 ### How to use AI Verification
 
-- Open a C/C++ file in VS Code  
+- Open a C, C++, Python or Solidity file in VS Code  
 - Press Ctrl + Shift + P  
 - Run: `ESBMC: Verify File with Local AI`
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "onLanguage:cpp",
     "onCommand:vscode-esbmc.verify.file",
     "onCommand:vscode-esbmc.install",
-    "onCommand:vscode-esbmc.update"
+    "onCommand:vscode-esbmc.update",
+    "onCommand:vscode-esbmc.showOutput"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -629,6 +630,26 @@
             "description": "Ollama model name used for analysis and explanation."
           }
         }
+      },
+      {
+        "id": "editor",
+        "title": "Editor Integration",
+        "order": 900,
+        "properties": {
+          "esbmc.editor.verifyOnSave": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Verify a supported file with ESBMC every time it is saved",
+            "order": 1
+          },
+          "esbmc.editor.timeout": {
+            "type": "number",
+            "default": 60,
+            "markdownDescription": "Kill a verification run after this many seconds, a value of `0` lets it run to completion",
+            "order": 2,
+            "minimum": 0
+          }
+        }
       }
     ],
     "commands": [
@@ -647,6 +668,10 @@
       {
         "command": "vscode-esbmc.verify.file.withAI",
         "title": "ESBMC: Verify file with Local AI"
+      },
+      {
+        "command": "vscode-esbmc.showOutput",
+        "title": "ESBMC: Show output"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "activationEvents": [
     "onLanguage:c",
     "onLanguage:cpp",
+    "onLanguage:python",
+    "onLanguage:solidity",
     "onCommand:vscode-esbmc.verify.file",
     "onCommand:vscode-esbmc.install",
     "onCommand:vscode-esbmc.update",

--- a/package.json
+++ b/package.json
@@ -778,5 +778,8 @@
     "mocha": {
       "serialize-javascript": "^7.1.0"
     }
-  }
+  },
+  "extensionKind": [
+    "workspace"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,18 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "languages": [
+      {
+        "id": "solidity",
+        "aliases": [
+          "Solidity",
+          "solidity"
+        ],
+        "extensions": [
+          ".sol"
+        ]
+      }
+    ],
     "configuration": [
       {
         "id": "front-end",

--- a/src/codelens/registerCodeLense.ts
+++ b/src/codelens/registerCodeLense.ts
@@ -1,12 +1,10 @@
 import { languages, Disposable, DocumentSelector } from 'vscode'
 import { EsbmcCodeLensProvider } from './codeLensProvider'
+import { SUPPORTED_LANGUAGES } from '../languages'
 
-const selector: DocumentSelector = [
-  { language: 'c', scheme: 'file' },
-  { language: 'cpp', scheme: 'file' },
-  { language: 'sol', scheme: 'file' },
-  { language: 'py', scheme: 'file' }
-]
+const selector: DocumentSelector = SUPPORTED_LANGUAGES.map(
+  language => ({ language: language.id, scheme: 'file' })
+)
 
 export function registerCodeLens (): Disposable[] {
   return [

--- a/src/commands/aiExplain.ts
+++ b/src/commands/aiExplain.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
-import { executeShellCommand } from '../utils/commands'
+import * as os from 'os'
+import * as path from 'path'
+import { executeShellCommand, quoteShellArg, runShellCommand } from '../utils/commands'
 import { callOllama } from '../ai/ollamaClient'
 
 export async function verifyWithAI (): Promise<void> {
@@ -25,19 +27,13 @@ export async function verifyWithAI (): Promise<void> {
   try {
     await executeShellCommand('esbmc --version')
   } catch {
-    esbmcCmd = '$HOME/bin/esbmc'
+    esbmcCmd = quoteShellArg(path.join(os.homedir(), 'bin', 'esbmc'))
   }
 
-  let esbmcOutput: string
-  try {
-    esbmcOutput = await executeShellCommand(`${esbmcCmd} "${filePath}"`)
-    if (!esbmcOutput || !esbmcOutput.trim()) {
-      esbmcOutput = await executeShellCommand(`${esbmcCmd} "${filePath}" 2>&1`)
-    }
-  } catch (error: any) {
-    // ESBMC retorna código != 0 quando há violação; ainda assim o output é útil
-    esbmcOutput = String(error)
-  }
+  // ESBMC prints its verdict on stderr and exits non-zero on a violation, so
+  // both streams are kept and a non-zero exit is a result, not an error.
+  const result = await runShellCommand(`${esbmcCmd} ${quoteShellArg(filePath)}`)
+  const esbmcOutput = result.stdout + result.stderr
 
   channel.appendLine('=== ESBMC Output ===\n')
   channel.appendLine(esbmcOutput.trim())

--- a/src/commands/aiExplain.ts
+++ b/src/commands/aiExplain.ts
@@ -3,6 +3,7 @@ import * as os from 'os'
 import * as path from 'path'
 import { executeShellCommand, quoteShellArg, runShellCommand } from '../utils/commands'
 import { callOllama } from '../ai/ollamaClient'
+import { editorTimeoutSeconds } from './run'
 
 export async function verifyWithAI (): Promise<void> {
   const editor = vscode.window.activeTextEditor
@@ -24,15 +25,30 @@ export async function verifyWithAI (): Promise<void> {
 
   // Try ESBMC, fallback to $HOME/bin
   let esbmcCmd = 'esbmc'
+  let cmd: string
   try {
-    await executeShellCommand('esbmc --version')
-  } catch {
-    esbmcCmd = quoteShellArg(path.join(os.homedir(), 'bin', 'esbmc'))
+    try {
+      await executeShellCommand('esbmc --version')
+    } catch {
+      esbmcCmd = quoteShellArg(path.join(os.homedir(), 'bin', 'esbmc'))
+    }
+    cmd = `${esbmcCmd} ${quoteShellArg(filePath)}`
+  } catch (error) {
+    channel.appendLine(`ESBMC: ${String(error)}`)
+    vscode.window.showErrorMessage(`ESBMC: ${String(error)}`)
+    return
   }
 
   // ESBMC prints its verdict on stderr and exits non-zero on a violation, so
   // both streams are kept and a non-zero exit is a result, not an error.
-  const result = await runShellCommand(`${esbmcCmd} ${quoteShellArg(filePath)}`)
+  // Bounded by the same setting a normal run uses: without it a
+  // non-terminating program leaves this waiting forever.
+  const timeoutSeconds = editorTimeoutSeconds()
+  const result = await runShellCommand(cmd, { timeoutMs: timeoutSeconds * 1000 })
+  if (result.timedOut) {
+    channel.appendLine(`\n[INFO] ESBMC was killed after ${timeoutSeconds}s (esbmc.editor.timeout)\n`)
+    return
+  }
   const esbmcOutput = result.stdout + result.stderr
 
   channel.appendLine('=== ESBMC Output ===\n')

--- a/src/commands/installation.ts
+++ b/src/commands/installation.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import { getApi, FileDownloader } from '@microsoft/vscode-file-downloader-api'
-import { getInstalledVersion, getLatestVersion } from '../utils/versions'
-import { quoteShellArg, runShellCommand } from '../utils/commands'
+import { getInstalledVersion, getLatestVersion, readVersion } from '../utils/versions'
+import { quoteShellArg, runProcess } from '../utils/commands'
 import { assetForPlatform, binaryPath, extractCommand, isSupportedPlatform } from '../utils/platform'
-import { installDir } from '../utils/esbmcPath'
+import { installDir, resolveEsbmc } from '../utils/esbmcPath'
 import { compare } from 'compare-versions'
 
 // Only want one of this running at a time
@@ -39,7 +39,20 @@ export async function install (context: vscode.ExtensionContext): Promise<void> 
 
 export async function update (context: vscode.ExtensionContext): Promise<void> {
   await withLock(async () => {
-    const installedVersion = await getInstalledVersion()
+    const esbmc = await resolveEsbmc()
+    if (esbmc === undefined) {
+      vscode.window.showInformationMessage('ESBMC is not installed try running esbmc.install')
+      return
+    }
+    // Installing into storage would change nothing while PATH still wins, so
+    // the update would be offered again on every invocation.
+    if (esbmc.source === 'path') {
+      vscode.window.showInformationMessage(
+        'ESBMC on your PATH is the one that runs, and this extension does not manage it. ' +
+        'Update it where you installed it, or take it off PATH to use esbmc.install.')
+      return
+    }
+    const installedVersion = await readVersion(esbmc.command)
     const latestVersion = await getLatestVersion()
     if (installedVersion === undefined) {
       vscode.window.showInformationMessage('ESBMC is not installed try running esbmc.install')
@@ -96,28 +109,42 @@ async function downloadAndInstall (context: vscode.ExtensionContext): Promise<st
       return undefined
     }
 
-    fs.rmSync(target, { recursive: true, force: true })
-    fs.mkdirSync(target, { recursive: true })
-    const extract = await runShellCommand(extractCommand(archive.fsPath, target, process.platform))
-    if (extract.code !== 0) {
-      vscode.window.showErrorMessage(`Could not unpack ESBMC: ${extract.stderr.trim()}`)
-      return undefined
-    }
+    // Unpacked beside the install rather than over it: a failed extraction
+    // must not be what is left where a working ESBMC used to be.
+    const staging = `${target}.incoming`
+    fs.rmSync(staging, { recursive: true, force: true })
+    fs.mkdirSync(staging, { recursive: true })
+    try {
+      const unpack = extractCommand(archive.fsPath, staging, process.platform)
+      const extract = await runProcess(unpack.file, unpack.args)
+      if (extract.code !== 0) {
+        vscode.window.showErrorMessage(`Could not unpack ESBMC: ${extract.stderr.trim()}`)
+        return undefined
+      }
 
-    const binary = binaryPath(target, process.platform)
-    if (!fs.existsSync(binary)) {
-      vscode.window.showErrorMessage(`Could not find esbmc in ${asset}`)
-      return undefined
-    }
-    if (process.platform !== 'win32') {
-      await runShellCommand(`chmod +x ${quoteShellArg(binary)}`)
-    }
+      const binary = binaryPath(staging, process.platform)
+      if (!fs.existsSync(binary)) {
+        vscode.window.showErrorMessage(`Could not find esbmc in ${asset}`)
+        return undefined
+      }
+      if (process.platform !== 'win32') {
+        await runProcess('chmod', ['+x', binary])
+      }
 
-    const installed = await getInstalledVersion()
-    if (installed === undefined) {
-      vscode.window.showErrorMessage('ESBMC was unpacked but does not run, see the ESBMC output')
+      // The binary just unpacked, not whatever the resolver would pick: an
+      // ESBMC on PATH would answer for it and hide a broken download.
+      const installed = await readVersion(quoteShellArg(binary))
+      if (installed === undefined) {
+        vscode.window.showErrorMessage('ESBMC was unpacked but does not run, see the ESBMC output')
+        return undefined
+      }
+
+      fs.rmSync(target, { recursive: true, force: true })
+      fs.renameSync(staging, target)
+      return installed
+    } finally {
+      fs.rmSync(staging, { recursive: true, force: true })
     }
-    return installed
   } finally {
     statusIcon.dispose()
   }

--- a/src/commands/installation.ts
+++ b/src/commands/installation.ts
@@ -1,120 +1,124 @@
 import * as vscode from 'vscode'
+import * as fs from 'fs'
 import { getApi, FileDownloader } from '@microsoft/vscode-file-downloader-api'
 import { getInstalledVersion, getLatestVersion } from '../utils/versions'
-import { executeShellCommand } from '../utils/commands'
+import { quoteShellArg, runShellCommand } from '../utils/commands'
+import { assetForPlatform, binaryPath, extractCommand, isSupportedPlatform } from '../utils/platform'
+import { installDir } from '../utils/esbmcPath'
 import { compare } from 'compare-versions'
 
 // Only want one of this running at a time
 let LOCK = false
 
-export async function install (context: vscode.ExtensionContext) {
+async function withLock (work: () => Promise<void>): Promise<void> {
   if (LOCK) {
     return
   }
   LOCK = true
-  let installedVersion = await getInstalledVersion()
-  if (installedVersion === undefined) {
-    const { file, downloadingStatusIcon }: { file: vscode.Uri; downloadingStatusIcon: vscode.StatusBarItem } = await downloadEsbmc(context)
-    if (file === undefined) {
-      vscode.window.showErrorMessage('Could not download ESBMC')
-      LOCK = false
-      return
-    }
-    const filePath = file.fsPath
-    const installed = await installFile(filePath)
-    if (!installed) { return }
-    downloadingStatusIcon.hide()
-    // Check that it has effectively installed
-    installedVersion = await getInstalledVersion()
-    if (installedVersion !== undefined) {
-      vscode.window.showInformationMessage(`Installed ESBMC ${installedVersion}`)
-    } else {
-      vscode.window.showInformationMessage('Could not install ESBMC, see terminal for output')
-    }
-  } else {
-    vscode.window.showInformationMessage(`ESBMC ${installedVersion} already installed, try esbmc.update to get the latest version`)
+  try {
+    await work()
+  } finally {
+    LOCK = false
   }
-  LOCK = false
 }
 
-export async function update (context: vscode.ExtensionContext) {
-  if (LOCK) {
-    return
-  }
-  LOCK = true
-  const installedVersion = await getInstalledVersion()
-  const latestVersion = await getLatestVersion()
-  if (installedVersion === undefined) {
-    vscode.window.showInformationMessage('ESBMC is not installed try running esbmc.install')
-    LOCK = false
-    return
-  }
-  if (latestVersion === undefined) {
-    vscode.window.showInformationMessage('ESBMC could not fetch latest version')
-    LOCK = false
-    return
-  }
-  if (compare(latestVersion, installedVersion, '>')) {
-    const { file, downloadingStatusIcon }: { file: vscode.Uri; downloadingStatusIcon: vscode.StatusBarItem } = await downloadEsbmc(context)
-    if (file === undefined) {
-      vscode.window.showErrorMessage('Could not download ESBMC')
-      LOCK = false
-      return
-    }
-    const filePath = file.fsPath
-    const installed = await installFile(filePath)
-    if (!installed) { return }
-    downloadingStatusIcon.hide()
-    const deleteOldCommand = 'rm $HOME/bin/esbmc.old'
-    const reinstateOldCommand = 'mv $HOME/bin/esbmc.old $HOME/bin/esbmc'
-    // Check that it has effectively installed
+export async function install (context: vscode.ExtensionContext): Promise<void> {
+  await withLock(async () => {
     const installedVersion = await getInstalledVersion()
     if (installedVersion !== undefined) {
-      await executeShellCommand(deleteOldCommand)
-      vscode.window.showInformationMessage(`Updated ESBMC to ${installedVersion}`)
-    } else {
-      await executeShellCommand(reinstateOldCommand)
-      vscode.window.showInformationMessage('Could not update ESBMC, see terminal for output')
+      vscode.window.showInformationMessage(
+        `ESBMC ${installedVersion} already installed, try esbmc.update to get the latest version`)
+      return
     }
-  } else {
-    vscode.window.showInformationMessage('ESBMC is up-to-date')
+    const version = await downloadAndInstall(context)
+    if (version !== undefined) {
+      vscode.window.showInformationMessage(`Installed ESBMC ${version}`)
+    }
+  })
+}
+
+export async function update (context: vscode.ExtensionContext): Promise<void> {
+  await withLock(async () => {
+    const installedVersion = await getInstalledVersion()
+    const latestVersion = await getLatestVersion()
+    if (installedVersion === undefined) {
+      vscode.window.showInformationMessage('ESBMC is not installed try running esbmc.install')
+      return
+    }
+    if (latestVersion === undefined) {
+      vscode.window.showInformationMessage('ESBMC could not fetch latest version')
+      return
+    }
+    if (!compare(latestVersion, installedVersion, '>')) {
+      vscode.window.showInformationMessage('ESBMC is up-to-date')
+      return
+    }
+    const version = await downloadAndInstall(context)
+    if (version !== undefined) {
+      vscode.window.showInformationMessage(`Updated ESBMC to ${version}`)
+    }
+  })
+}
+
+/**
+ * Downloads the build for this platform and unpacks it into the extension's
+ * own storage. The whole `bin/` directory is kept: on Windows `esbmc.exe`
+ * needs the `libz3.dll` shipped beside it.
+ *
+ * @returns the installed version, or undefined if anything went wrong.
+ */
+async function downloadAndInstall (context: vscode.ExtensionContext): Promise<string | undefined> {
+  if (!isSupportedPlatform(process.platform)) {
+    vscode.window.showErrorMessage(
+      `ESBMC: no build is published for ${process.platform}. Use Remote-SSH, WSL or a Dev Container.`)
+    return undefined
   }
-  LOCK = false
-}
-async function downloadEsbmc (context: vscode.ExtensionContext) {
-  const fileDownloader: FileDownloader = await getApi()
-  const downloadingStatusIcon = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0)
-  downloadingStatusIcon.text = '$(loading~spin) Installing ESBMC '
-  downloadingStatusIcon.show()
-  const file: vscode.Uri = await fileDownloader.downloadFile(
-    vscode.Uri.parse('https://github.com/esbmc/esbmc/releases/latest/download/ESBMC-Linux.zip'),
-    'ESBMC-Linux.zip',
-    context
-  )
-  return { file, downloadingStatusIcon }
-}
 
-async function installFile (filePath: string) {
-  let out
-  const setupBinDirCommand = 'mkdir -p "$HOME/bin"'
-  const renameOldCommand = 'if [ -f "$HOME/bin/esbmc" ]; then mv "$HOME/bin/esbmc" "$HOME/bin/esbmc.old"; fi'
-  const setupInstallLocationCommand = 'rm -rf "$HOME/bin/esbmc-folder" && mkdir -p "$HOME/bin/esbmc-folder"'
-  const unzipCommand = `unzip -o "${filePath}" -d "$HOME/bin/esbmc-folder"`
-  const moveCommand = 'mv "$HOME/bin/esbmc-folder/bin/esbmc" "$HOME/bin/esbmc"'
-  const chmodCommand = 'chmod +x "$HOME/bin/esbmc"'
-  const cleanupCommand = `rm -rf "$HOME/bin/esbmc-folder" "${filePath}"`
+  const target = installDir()
+  if (target === undefined) {
+    vscode.window.showErrorMessage('ESBMC: the extension is not activated, cannot install')
+    return undefined
+  }
 
+  const asset = assetForPlatform(process.platform)
+  const statusIcon = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0)
+  statusIcon.text = '$(loading~spin) Installing ESBMC '
+  statusIcon.show()
   try {
-    out = await executeShellCommand(setupBinDirCommand)
-    out = await executeShellCommand(renameOldCommand)
-    out = await executeShellCommand(setupInstallLocationCommand)
-    out = await executeShellCommand(unzipCommand)
-    out = await executeShellCommand(moveCommand)
-    out = await executeShellCommand(chmodCommand)
-    out = await executeShellCommand(cleanupCommand)
-  } catch (error) {
-    vscode.window.showInformationMessage(`Could not update ESBMC\n ${out}`)
-    return false
+    const fileDownloader: FileDownloader = await getApi()
+    const archive = await fileDownloader.downloadFile(
+      vscode.Uri.parse(`https://github.com/esbmc/esbmc/releases/latest/download/${asset}`),
+      asset,
+      context
+    )
+    if (archive === undefined) {
+      vscode.window.showErrorMessage('Could not download ESBMC')
+      return undefined
+    }
+
+    fs.rmSync(target, { recursive: true, force: true })
+    fs.mkdirSync(target, { recursive: true })
+    const extract = await runShellCommand(extractCommand(archive.fsPath, target, process.platform))
+    if (extract.code !== 0) {
+      vscode.window.showErrorMessage(`Could not unpack ESBMC: ${extract.stderr.trim()}`)
+      return undefined
+    }
+
+    const binary = binaryPath(target, process.platform)
+    if (!fs.existsSync(binary)) {
+      vscode.window.showErrorMessage(`Could not find esbmc in ${asset}`)
+      return undefined
+    }
+    if (process.platform !== 'win32') {
+      await runShellCommand(`chmod +x ${quoteShellArg(binary)}`)
+    }
+
+    const installed = await getInstalledVersion()
+    if (installed === undefined) {
+      vscode.window.showErrorMessage('ESBMC was unpacked but does not run, see the ESBMC output')
+    }
+    return installed
+  } finally {
+    statusIcon.dispose()
   }
-  return true
 }

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -1,5 +1,5 @@
 import { commands, Disposable, ExtensionContext } from 'vscode'
-import { run } from './run'
+import { run, showOutput } from './run'
 import { install, update } from './installation'
 
 export function registerCommands (context: ExtensionContext): Disposable[] {
@@ -7,6 +7,7 @@ export function registerCommands (context: ExtensionContext): Disposable[] {
     commands.registerCommand('vscode-esbmc.verify.file', async () => run()),
     commands.registerCommand('vscode-esbmc.verify.function', async (overrides, commentFlags) => run(overrides, commentFlags)),
     commands.registerCommand('vscode-esbmc.install', async () => install(context)),
-    commands.registerCommand('vscode-esbmc.update', async () => update(context))
+    commands.registerCommand('vscode-esbmc.update', async () => update(context)),
+    commands.registerCommand('vscode-esbmc.showOutput', () => showOutput())
   ]
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -4,11 +4,12 @@ import * as os from 'os'
 import * as path from 'path'
 import { ConfigurationParser } from '../parsers/configParser'
 import { Configuration } from '../@types/vscode.configuration'
-import { executeShellCommand, quoteShellArg, runShellCommand } from '../utils/commands'
+import { quoteShellArg, runShellCommand } from '../utils/commands'
 import { parseSarif, resolveFindingPaths, EsbmcFinding } from '../parsers/sarifParser'
 import { classifyVerdict, statusText } from '../parsers/verdict'
 import { EsbmcDiagnostics } from '../diagnostics/esbmcDiagnostics'
 import { SUPPORTED_EXTENSIONS } from '../languages'
+import { resolveEsbmcCommand } from '../utils/esbmcPath'
 
 const CONFIG_PARSER: ConfigurationParser = new ConfigurationParser()
 
@@ -95,6 +96,10 @@ export async function run (overides?: Configuration, commentFlags?: string, docu
   }
 
   const esbmcCmd = await resolveEsbmcCommand()
+  if (esbmcCmd === undefined) {
+    vscode.window.showErrorMessage('ESBMC: not found, try running "ESBMC: Install latest version"')
+    return
+  }
   const configured = vscode.workspace.getConfiguration('esbmc.editor').get<number>('timeout', 60)
   const timeoutSeconds = Number.isFinite(configured) ? Math.max(0, configured) : 60
 
@@ -141,19 +146,6 @@ export async function run (overides?: Configuration, commentFlags?: string, docu
     }
   } finally {
     fs.rmSync(reportDir, { recursive: true, force: true })
-  }
-}
-
-/**
- * ESBMC is preferred from PATH, falling back to where the install command puts
- * it. Deliberately not cached: the install command can add it mid-session.
- */
-async function resolveEsbmcCommand (): Promise<string> {
-  try {
-    await executeShellCommand('esbmc --version')
-    return 'esbmc'
-  } catch {
-    return quoteShellArg(path.join(os.homedir(), 'bin', 'esbmc'))
   }
 }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,8 +8,8 @@ import { executeShellCommand, quoteShellArg, runShellCommand } from '../utils/co
 import { parseSarif, resolveFindingPaths, EsbmcFinding } from '../parsers/sarifParser'
 import { classifyVerdict, statusText } from '../parsers/verdict'
 import { EsbmcDiagnostics } from '../diagnostics/esbmcDiagnostics'
+import { SUPPORTED_EXTENSIONS } from '../languages'
 
-const SUPPORTED_EXTENSIONS = new Set(['c', 'cpp', 'sol', 'jimple', 'py'])
 const CONFIG_PARSER: ConfigurationParser = new ConfigurationParser()
 
 let OUTPUT: vscode.OutputChannel | undefined

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -42,6 +42,12 @@ function diagnostics (): EsbmcDiagnostics {
   return DIAGNOSTICS
 }
 
+/** `esbmc.editor.timeout`, shared so every ESBMC run is bounded the same way. */
+export function editorTimeoutSeconds (): number {
+  const configured = vscode.workspace.getConfiguration('esbmc.editor').get<number>('timeout', 60)
+  return Number.isFinite(configured) ? Math.max(0, configured) : 60
+}
+
 export function showOutput (): void {
   output().show(true)
 }
@@ -95,8 +101,7 @@ export async function run (overides?: Configuration, commentFlags?: string, docu
   }
 
   const esbmcCmd = await resolveEsbmcCommand()
-  const configured = vscode.workspace.getConfiguration('esbmc.editor').get<number>('timeout', 60)
-  const timeoutSeconds = Number.isFinite(configured) ? Math.max(0, configured) : 60
+  const timeoutSeconds = editorTimeoutSeconds()
 
   // Supersede any run still going: its output would interleave with this one.
   const token = ++runToken
@@ -113,7 +118,17 @@ export async function run (overides?: Configuration, commentFlags?: string, docu
   const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-'))
   const report = path.join(reportDir, 'result.sarif')
   try {
-    const cmd = `${esbmcCmd} ${quoteShellArg(filePath)} ${flags} --sarif-output ${quoteShellArg(report)}`
+    let cmd: string
+    try {
+      cmd = `${esbmcCmd} ${quoteShellArg(filePath)} ${flags} --sarif-output ${quoteShellArg(report)}`
+    } catch (error) {
+      // A path cmd.exe cannot be given. Refusing is the point; say so rather
+      // than verifying whatever the rewritten path names.
+      showStatus('$(error) ESBMC: cannot run')
+      channel.appendLine(`\nESBMC: ${String(error)}`)
+      vscode.window.showErrorMessage(`ESBMC: ${String(error)}`)
+      return
+    }
     channel.appendLine(cmd)
 
     const result = await runShellCommand(cmd, {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,53 +1,171 @@
 import * as vscode from 'vscode'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
 import { ConfigurationParser } from '../parsers/configParser'
 import { Configuration } from '../@types/vscode.configuration'
-import { executeShellCommand } from '../utils/commands'
+import { executeShellCommand, quoteShellArg, runShellCommand } from '../utils/commands'
+import { parseSarif, resolveFindingPaths, EsbmcFinding } from '../parsers/sarifParser'
+import { classifyVerdict, statusText } from '../parsers/verdict'
+import { EsbmcDiagnostics } from '../diagnostics/esbmcDiagnostics'
 
 const SUPPORTED_EXTENSIONS = new Set(['c', 'cpp', 'sol', 'jimple', 'py'])
 const CONFIG_PARSER: ConfigurationParser = new ConfigurationParser()
 
-/**
- * Takes a path and extracts the file extension.
- */
-export async function run (overides?: Configuration, commentFlags?: string):Promise<void> {
-  // Set overides to empty object if undefined
-  overides = overides || {}
-  const activeTextEditor = vscode.window.activeTextEditor
-  if (activeTextEditor !== undefined) {
-    const currentlyOpenTabfilePath = activeTextEditor.document.fileName
-    const fileExt = getFileExtension(currentlyOpenTabfilePath)
-    if (fileExt === undefined) {
-      vscode.window.showErrorMessage('ESBMC: Cannot determine file type, not checking')
+let OUTPUT: vscode.OutputChannel | undefined
+let STATUS: vscode.StatusBarItem | undefined
+let DIAGNOSTICS: EsbmcDiagnostics | undefined
+let disposed = false
+
+// Only the newest run may touch the shared channel, status bar and
+// diagnostics: a save-triggered run can otherwise overwrite a manual one.
+let runToken = 0
+let killInFlight: (() => void) | undefined
+
+function output (): vscode.OutputChannel {
+  OUTPUT = OUTPUT ?? vscode.window.createOutputChannel('ESBMC')
+  return OUTPUT
+}
+
+function status (): vscode.StatusBarItem {
+  if (STATUS === undefined) {
+    STATUS = vscode.window.createStatusBarItem('esbmc.verdict', vscode.StatusBarAlignment.Left, 0)
+    STATUS.name = 'ESBMC'
+    STATUS.tooltip = 'Show the ESBMC output'
+    STATUS.command = 'vscode-esbmc.showOutput'
+  }
+  return STATUS
+}
+
+function diagnostics (): EsbmcDiagnostics {
+  DIAGNOSTICS = DIAGNOSTICS ?? new EsbmcDiagnostics()
+  return DIAGNOSTICS
+}
+
+export function showOutput (): void {
+  output().show(true)
+}
+
+export function disposeRunState (): void {
+  disposed = true
+  killInFlight?.()
+  OUTPUT?.dispose()
+  STATUS?.dispose()
+  DIAGNOSTICS?.dispose()
+  OUTPUT = undefined
+  STATUS = undefined
+  DIAGNOSTICS = undefined
+}
+
+function showStatus (text: string): void {
+  const item = status()
+  item.text = text
+  item.show()
+}
+
+export async function run (overides?: Configuration, commentFlags?: string, document?: vscode.TextDocument): Promise<void> {
+  overides = overides ?? {}
+  const target = document ?? vscode.window.activeTextEditor?.document
+  if (target === undefined) {
+    vscode.window.showErrorMessage('ESBMC: No file open, not checking')
+    return
+  }
+
+  const filePath = target.fileName
+  const fileExt = getFileExtension(filePath)
+  if (fileExt === undefined) {
+    vscode.window.showErrorMessage('ESBMC: Cannot determine file type, not checking')
+    return
+  }
+  if (!SUPPORTED_EXTENSIONS.has(fileExt)) {
+    vscode.window.showErrorMessage(`ESBMC: Currently no support for .${fileExt}, not checking`)
+    return
+  }
+
+  let flags: string
+  if (commentFlags !== undefined) {
+    flags = commentFlags
+  } else {
+    try {
+      flags = CONFIG_PARSER.parse(overides)
+    } catch (error) {
+      vscode.window.showErrorMessage(`ESBMC: ${error}`)
       return
     }
-    if (SUPPORTED_EXTENSIONS.has(fileExt!)) {
-      let flags: string
-      // If comment flags have been passed, use them instead of parsing
-      if (commentFlags !== undefined) {
-        flags = commentFlags
-      } else {
-        try {
-          flags = CONFIG_PARSER.parse(overides)
-        } catch (error) {
-          vscode.window.showErrorMessage(`ESBMC: ${error}`)
-          return
-        }
-      }
-      let esbmcCmd = 'esbmc'
-      try {
-        await executeShellCommand('esbmc --version')
-      } catch {
-        esbmcCmd = '$HOME/bin/esbmc'
-      }
-      const cmd = `${esbmcCmd} ${currentlyOpenTabfilePath} ${flags}`
-      const terminal = vscode.window.createTerminal('ESBMC')
-      terminal.show()
-      terminal.sendText(cmd)
-    } else {
-      vscode.window.showErrorMessage(`ESBMC: Currently no support for .${fileExt}, not checking`)
+  }
+
+  const esbmcCmd = await resolveEsbmcCommand()
+  const configured = vscode.workspace.getConfiguration('esbmc.editor').get<number>('timeout', 60)
+  const timeoutSeconds = Number.isFinite(configured) ? Math.max(0, configured) : 60
+
+  // Supersede any run still going: its output would interleave with this one.
+  const token = ++runToken
+  killInFlight?.()
+  if (disposed) { return }
+
+  diagnostics().clear()
+  showStatus('$(loading~spin) ESBMC: verifying')
+  const channel = output()
+  channel.clear()
+  channel.show(true)
+
+  const workingDir = path.dirname(filePath)
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-'))
+  const report = path.join(reportDir, 'result.sarif')
+  try {
+    const cmd = `${esbmcCmd} ${quoteShellArg(filePath)} ${flags} --sarif-output ${quoteShellArg(report)}`
+    channel.appendLine(cmd)
+
+    const result = await runShellCommand(cmd, {
+      timeoutMs: timeoutSeconds * 1000,
+      onStart: kill => { killInFlight = kill }
+    })
+    if (token !== runToken || disposed) { return }
+    killInFlight = undefined
+
+    channel.append(result.stdout)
+    channel.append(result.stderr)
+
+    const findings = result.timedOut ? [] : resolveFindingPaths(readFindings(report, channel), workingDir)
+    diagnostics().report(findings)
+
+    // ESBMC prints its verdict on stderr and only its version banner on stdout.
+    showStatus(statusText(classifyVerdict({
+      transcript: result.stdout + result.stderr,
+      findings,
+      timedOut: result.timedOut,
+      timeoutSeconds
+    })))
+    if (result.timedOut) {
+      channel.appendLine(`\nESBMC: killed after ${timeoutSeconds}s (esbmc.editor.timeout)`)
     }
-  } else {
-    vscode.window.showErrorMessage('ESBMC: No file open, not checking')
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true })
+  }
+}
+
+/**
+ * ESBMC is preferred from PATH, falling back to where the install command puts
+ * it. Deliberately not cached: the install command can add it mid-session.
+ */
+async function resolveEsbmcCommand (): Promise<string> {
+  try {
+    await executeShellCommand('esbmc --version')
+    return 'esbmc'
+  } catch {
+    return quoteShellArg(path.join(os.homedir(), 'bin', 'esbmc'))
+  }
+}
+
+function readFindings (report: string, channel: vscode.OutputChannel): EsbmcFinding[] {
+  if (!fs.existsSync(report)) {
+    return []
+  }
+  try {
+    return parseSarif(fs.readFileSync(report, 'utf8'))
+  } catch (error) {
+    channel.appendLine(`\nESBMC: could not read the SARIF report (${String(error)})`)
+    return []
   }
 }
 
@@ -55,9 +173,12 @@ export async function run (overides?: Configuration, commentFlags?: string):Prom
  * Takes a path and extracts the file extension.
  * @param file Full path to the file.
  */
-function getFileExtension (file:string): string | undefined {
-  const fileExt = file.split('.').pop()
-  // If there is no file extension this holds
-  if (fileExt === file) { return undefined }
-  return fileExt
+function getFileExtension (file: string): string | undefined {
+  const fileExt = path.extname(file).slice(1).toLowerCase()
+  return fileExt === '' ? undefined : fileExt
+}
+
+export function isSupported (document: vscode.TextDocument): boolean {
+  const fileExt = getFileExtension(document.fileName)
+  return fileExt !== undefined && SUPPORTED_EXTENSIONS.has(fileExt)
 }

--- a/src/diagnostics/esbmcDiagnostics.ts
+++ b/src/diagnostics/esbmcDiagnostics.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode'
+import { EsbmcFinding, FindingSeverity } from '../parsers/sarifParser'
+
+const SEVERITIES: Record<FindingSeverity, vscode.DiagnosticSeverity> = {
+  error: vscode.DiagnosticSeverity.Error,
+  warning: vscode.DiagnosticSeverity.Warning,
+  note: vscode.DiagnosticSeverity.Information
+}
+
+/**
+ * SARIF counts lines and columns from 1, VS Code from 0.
+ *
+ * ESBMC reports a line but no column, and an empty range at column 0 renders
+ * as no squiggle at all on an indented line, because VS Code only widens an
+ * empty range when a word sits at that position. So the range spans the line's
+ * text, from its first non-whitespace character to its end.
+ *
+ * @param lineText The source line, when it is available to measure.
+ */
+export function toDiagnostic (finding: EsbmcFinding, lineText?: string): vscode.Diagnostic {
+  const line = Math.max(0, finding.line - 1)
+  const indent = lineText === undefined ? 0 : lineText.length - lineText.trimStart().length
+  const start = finding.column !== undefined ? Math.max(0, finding.column - 1) : indent
+  const end = lineText === undefined ? Number.MAX_SAFE_INTEGER : Math.max(start, lineText.trimEnd().length)
+
+  const diagnostic = new vscode.Diagnostic(
+    new vscode.Range(line, start, line, end),
+    finding.cwes.length > 0 ? `${finding.message} (${finding.cwes.join(', ')})` : finding.message,
+    SEVERITIES[finding.severity]
+  )
+  diagnostic.source = 'ESBMC'
+  if (finding.ruleId !== undefined) {
+    diagnostic.code = finding.ruleId
+  }
+  return diagnostic
+}
+
+function lineTextOf (file: string, line: number): string | undefined {
+  const document = vscode.workspace.textDocuments.find(open => open.fileName === file)
+  if (document === undefined || line < 1 || line > document.lineCount) {
+    return undefined
+  }
+  return document.lineAt(line - 1).text
+}
+
+export class EsbmcDiagnostics {
+  private readonly collection: vscode.DiagnosticCollection
+
+  public constructor () {
+    this.collection = vscode.languages.createDiagnosticCollection('esbmc')
+  }
+
+  public report (findings: EsbmcFinding[]): void {
+    const byFile = new Map<string, vscode.Diagnostic[]>()
+    for (const finding of findings) {
+      const diagnostics = byFile.get(finding.file) ?? []
+      diagnostics.push(toDiagnostic(finding, lineTextOf(finding.file, finding.line)))
+      byFile.set(finding.file, diagnostics)
+    }
+    for (const [file, diagnostics] of byFile) {
+      this.collection.set(vscode.Uri.file(file), diagnostics)
+    }
+  }
+
+  /**
+   * A run's findings are the whole truth for that run, and a violation can be
+   * reported against an included header rather than the file being verified,
+   * so everything is cleared rather than just the entry file.
+   */
+  public clear (): void {
+    this.collection.clear()
+  }
+
+  public dispose (): void {
+    this.collection.dispose()
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { registerCodeLens } from './codelens/registerCodeLense'
 import { registerCommands } from './commands/registerCommands'
 import { verifyWithAI } from './commands/aiExplain'
 import { disposeRunState, isSupported, run } from './commands/run'
+import { setStorageRoot } from './utils/esbmcPath'
 
 // Autosave can fire every second or so, and a verification run is far from
 // free, so saves are coalesced rather than queued.
@@ -15,6 +16,7 @@ const SAVE_DEBOUNCE_MS = 500
 // your extension is activated the very first time the command is executed
 export function activate (context: vscode.ExtensionContext) {
   console.log('Congratulations, your extension "vscode-esbmc" is now active!')
+  setStorageRoot(context.globalStorageUri.fsPath)
   // Register Commands
   context.subscriptions.push(...registerCommands(context))
   context.subscriptions.push(...registerCodeLens())

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,11 @@ import * as vscode from 'vscode'
 import { registerCodeLens } from './codelens/registerCodeLense'
 import { registerCommands } from './commands/registerCommands'
 import { verifyWithAI } from './commands/aiExplain'
+import { disposeRunState, isSupported, run } from './commands/run'
+
+// Autosave can fire every second or so, and a verification run is far from
+// free, so saves are coalesced rather than queued.
+const SAVE_DEBOUNCE_MS = 500
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -15,6 +20,27 @@ export function activate (context: vscode.ExtensionContext) {
   context.subscriptions.push(...registerCodeLens())
   const aiCommand = vscode.commands.registerCommand('vscode-esbmc.verify.file.withAI', verifyWithAI)
   context.subscriptions.push(aiCommand)
+
+  let saveTimer: ReturnType<typeof setTimeout> | undefined
+  context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(document => {
+    const enabled = vscode.workspace.getConfiguration('esbmc.editor').get<boolean>('verifyOnSave', false)
+    if (!enabled || !isSupported(document)) {
+      return
+    }
+    clearTimeout(saveTimer)
+    saveTimer = setTimeout(() => {
+      run(undefined, undefined, document).catch(error => {
+        vscode.window.showErrorMessage(`ESBMC: ${String(error)}`)
+      })
+    }, SAVE_DEBOUNCE_MS)
+  }))
+
+  context.subscriptions.push({
+    dispose: () => {
+      clearTimeout(saveTimer)
+      disposeRunState()
+    }
+  })
 }
 
 // this method is called when your extension is deactivated

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,14 +1,33 @@
 export interface SupportedLanguage {
   /** VS Code language identifier, which is not always the file extension. */
   id: string
+  /**
+   * Every extension VS Code maps to this id that ESBMC can verify. The
+   * extension activates for the id, so anything missing here gets a CodeLens
+   * and then a refusal from run().
+   */
   extensions: string[]
 }
 
 export const SUPPORTED_LANGUAGES: SupportedLanguage[] = [
-  { id: 'c', extensions: ['c'] },
-  { id: 'cpp', extensions: ['cpp'] },
+  { id: 'c', extensions: ['c', 'i'] },
+  { id: 'cpp', extensions: ['cpp', 'cc', 'cxx'] },
   { id: 'python', extensions: ['py'] },
+  // Contributed by this extension: VS Code ships no solidity language, so
+  // without it onLanguage:solidity never fires and .sol files have no id.
   { id: 'solidity', extensions: ['sol'] }
+]
+
+/**
+ * Extensions VS Code maps to a language above that ESBMC cannot verify.
+ *
+ * ESBMC chooses its frontend by extension and rejects each of these with
+ * "failed to figure out type of file", so refusing them in the editor is the
+ * accurate answer rather than a gap. Verified against ESBMC 8.4.0.
+ */
+export const UNVERIFIABLE_EXTENSIONS = [
+  'h', 'hpp', 'hh', 'hxx', 'h++', 'c++', 'ii',
+  'pyi', 'pyw', 'rpy', 'cpy', 'gyp', 'gypi', 'ipy'
 ]
 
 /** Accepted by ESBMC but with no VS Code language of their own. */

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,0 +1,20 @@
+export interface SupportedLanguage {
+  /** VS Code language identifier, which is not always the file extension. */
+  id: string
+  extensions: string[]
+}
+
+export const SUPPORTED_LANGUAGES: SupportedLanguage[] = [
+  { id: 'c', extensions: ['c'] },
+  { id: 'cpp', extensions: ['cpp'] },
+  { id: 'python', extensions: ['py'] },
+  { id: 'solidity', extensions: ['sol'] }
+]
+
+/** Accepted by ESBMC but with no VS Code language of their own. */
+const EXTRA_EXTENSIONS = ['jimple']
+
+export const SUPPORTED_EXTENSIONS = new Set([
+  ...SUPPORTED_LANGUAGES.flatMap(language => language.extensions),
+  ...EXTRA_EXTENSIONS
+])

--- a/src/parsers/sarifParser.ts
+++ b/src/parsers/sarifParser.ts
@@ -1,0 +1,80 @@
+import * as path from 'path'
+
+export type FindingSeverity = 'error' | 'warning' | 'note'
+
+export interface EsbmcFinding {
+  file: string
+  line: number
+  column?: number
+  message: string
+  ruleId?: string
+  severity: FindingSeverity
+  cwes: string[]
+}
+
+const SEVERITIES: Record<string, FindingSeverity> = {
+  error: 'error',
+  warning: 'warning',
+  note: 'note',
+  none: 'note'
+}
+
+function findingFrom (result: any, location: any): EsbmcFinding | undefined {
+  const physical = location?.physicalLocation
+  const file = physical?.artifactLocation?.uri
+  if (typeof file !== 'string' || file === '') {
+    return undefined
+  }
+  const message = result?.message?.text
+  if (typeof message !== 'string' || message === '') {
+    return undefined
+  }
+  return {
+    file: file.replace(/^file:\/\//, ''),
+    line: physical?.region?.startLine ?? 1,
+    column: physical?.region?.startColumn,
+    message,
+    ruleId: typeof result?.ruleId === 'string' ? result.ruleId : undefined,
+    severity: SEVERITIES[result?.level] ?? 'error',
+    cwes: (result?.taxa ?? [])
+      .filter((taxon: any) => taxon?.toolComponent?.name === 'CWE' && taxon?.id !== undefined)
+      .map((taxon: any) => `CWE-${String(taxon.id)}`)
+  }
+}
+
+/**
+ * Turns an ESBMC SARIF 2.1.0 report into the violated properties it records.
+ *
+ * ESBMC emits one result per violated property, so a report with no results
+ * means the run proved every property it checked.
+ *
+ * @throws SyntaxError if the report is not valid JSON.
+ */
+export function parseSarif (report: string): EsbmcFinding[] {
+  const sarif = JSON.parse(report)
+  const findings: EsbmcFinding[] = []
+  for (const run of sarif?.runs ?? []) {
+    for (const result of run?.results ?? []) {
+      // A result with no locations cannot be shown against source.
+      for (const location of result?.locations ?? []) {
+        const finding = findingFrom(result, location)
+        if (finding !== undefined) {
+          findings.push(finding)
+        }
+      }
+    }
+  }
+  return findings
+}
+
+/**
+ * ESBMC echoes back the path shape it was given, so a finding against an
+ * included header can be relative to where ESBMC ran. A relative path would
+ * otherwise become a diagnostic on a file that does not exist.
+ */
+export function resolveFindingPaths (findings: EsbmcFinding[], base: string): EsbmcFinding[] {
+  return findings.map(finding => ({
+    ...finding,
+    file: path.isAbsolute(finding.file) ? finding.file : path.resolve(base, finding.file)
+  }))
+}

--- a/src/parsers/verdict.ts
+++ b/src/parsers/verdict.ts
@@ -1,0 +1,53 @@
+import { EsbmcFinding } from './sarifParser'
+
+export type Verdict =
+  | { kind: 'timeout', seconds: number }
+  | { kind: 'violations', count: number }
+  | { kind: 'success' }
+  | { kind: 'failed-without-findings' }
+  | { kind: 'unknown' }
+
+export interface RunOutcome {
+  transcript: string
+  findings: EsbmcFinding[]
+  timedOut: boolean
+  timeoutSeconds: number
+}
+
+/**
+ * Decides what a run means.
+ *
+ * ESBMC prints its verdict on stderr, so `transcript` has to be both streams
+ * joined. A run can also fail with nothing to place: `--sarif-output` writes no
+ * report under `--multi-property`, so findings can be empty even on failure.
+ */
+export function classifyVerdict (outcome: RunOutcome): Verdict {
+  if (outcome.timedOut) {
+    return { kind: 'timeout', seconds: outcome.timeoutSeconds }
+  }
+  if (outcome.findings.length > 0) {
+    return { kind: 'violations', count: outcome.findings.length }
+  }
+  if (outcome.transcript.includes('VERIFICATION SUCCESSFUL')) {
+    return { kind: 'success' }
+  }
+  if (outcome.transcript.includes('VERIFICATION FAILED')) {
+    return { kind: 'failed-without-findings' }
+  }
+  return { kind: 'unknown' }
+}
+
+export function statusText (verdict: Verdict): string {
+  switch (verdict.kind) {
+    case 'timeout':
+      return `$(clock) ESBMC: timed out after ${verdict.seconds}s`
+    case 'violations':
+      return `$(error) ESBMC: ${verdict.count} propert${verdict.count === 1 ? 'y' : 'ies'} violated`
+    case 'success':
+      return '$(check) ESBMC: verified'
+    case 'failed-without-findings':
+      return '$(error) ESBMC: failed, see output'
+    case 'unknown':
+      return '$(question) ESBMC: no verdict'
+  }
+}

--- a/src/test/diagnostics/EsbmcDiagnostics.test.ts
+++ b/src/test/diagnostics/EsbmcDiagnostics.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { toDiagnostic } from '../../diagnostics/esbmcDiagnostics'
+import { EsbmcFinding } from '../../parsers/sarifParser'
+
+function finding (overrides: Partial<EsbmcFinding> = {}): EsbmcFinding {
+  return {
+    file: '/a.c',
+    line: 13,
+    message: 'array bounds violated',
+    severity: 'error',
+    cwes: [],
+    ...overrides
+  }
+}
+
+describe('toDiagnostic', () => {
+  // SARIF counts lines and columns from 1, VS Code from 0.
+  it('converts the location to a zero-based range', () => {
+    const diagnostic = toDiagnostic(finding({ line: 13, column: 5 }))
+    assert.strictEqual(diagnostic.range.start.line, 12)
+    assert.strictEqual(diagnostic.range.start.character, 4)
+  })
+
+  it('starts at the beginning of the line when ESBMC gives no column', () => {
+    assert.strictEqual(toDiagnostic(finding()).range.start.character, 0)
+  })
+
+  it('never produces a negative position', () => {
+    const diagnostic = toDiagnostic(finding({ line: 0, column: 0 }))
+    assert.strictEqual(diagnostic.range.start.line, 0)
+    assert.strictEqual(diagnostic.range.start.character, 0)
+  })
+
+  it('maps severities onto the VS Code scale', () => {
+    assert.strictEqual(toDiagnostic(finding({ severity: 'error' })).severity, vscode.DiagnosticSeverity.Error)
+    assert.strictEqual(toDiagnostic(finding({ severity: 'warning' })).severity, vscode.DiagnosticSeverity.Warning)
+    assert.strictEqual(toDiagnostic(finding({ severity: 'note' })).severity, vscode.DiagnosticSeverity.Information)
+  })
+
+  it('attributes the diagnostic to ESBMC and its property', () => {
+    const diagnostic = toDiagnostic(finding({ ruleId: 'array-bounds-violated' }))
+    assert.strictEqual(diagnostic.source, 'ESBMC')
+    assert.strictEqual(diagnostic.code, 'array-bounds-violated')
+  })
+
+  it('appends the CWEs to the message when ESBMC reports any', () => {
+    assert.strictEqual(
+      toDiagnostic(finding({ cwes: ['CWE-125', 'CWE-787'] })).message,
+      'array bounds violated (CWE-125, CWE-787)'
+    )
+    assert.strictEqual(toDiagnostic(finding()).message, 'array bounds violated')
+  })
+})

--- a/src/test/diagnostics/EsbmcDiagnostics.test.ts
+++ b/src/test/diagnostics/EsbmcDiagnostics.test.ts
@@ -32,6 +32,43 @@ describe('toDiagnostic', () => {
     assert.strictEqual(diagnostic.range.start.character, 0)
   })
 
+  // The reason lineText exists: an empty range at column 0 renders as no
+  // squiggle at all on an indented line, so the range has to span the code.
+  it('spans the code on the line when the source is available', () => {
+    const diagnostic = toDiagnostic(finding(), '    values[i] = i;')
+    assert.strictEqual(diagnostic.range.start.character, 4, 'starts at the first non-whitespace character')
+    assert.strictEqual(diagnostic.range.end.character, 18, 'ends at the last')
+  })
+
+  it('stops at the end of the code, not the end of the trailing whitespace', () => {
+    const diagnostic = toDiagnostic(finding(), '  x = 1;   ')
+    assert.strictEqual(diagnostic.range.start.character, 2)
+    assert.strictEqual(diagnostic.range.end.character, 8)
+  })
+
+  // ESBMC gives no column, but a comment-flag override or another producer can.
+  it('keeps a reported column as the start, and never ends before it', () => {
+    const withColumn = toDiagnostic(finding({ column: 7 }), '    values[i] = i;')
+    assert.strictEqual(withColumn.range.start.character, 6)
+
+    const pastTheEnd = toDiagnostic(finding({ column: 40 }), '  x = 1;')
+    assert.ok(
+      pastTheEnd.range.end.character >= pastTheEnd.range.start.character,
+      'the range ends before it starts'
+    )
+  })
+
+  it('spans a blank line without inverting the range', () => {
+    const diagnostic = toDiagnostic(finding(), '    ')
+    assert.strictEqual(diagnostic.range.start.character, 4)
+    assert.strictEqual(diagnostic.range.end.character, 4)
+  })
+
+  // Without the source, the range runs to the end of whatever is there.
+  it('runs to the end of the line when the source is not available', () => {
+    assert.strictEqual(toDiagnostic(finding()).range.end.character, Number.MAX_SAFE_INTEGER)
+  })
+
   it('maps severities onto the VS Code scale', () => {
     assert.strictEqual(toDiagnostic(finding({ severity: 'error' })).severity, vscode.DiagnosticSeverity.Error)
     assert.strictEqual(toDiagnostic(finding({ severity: 'warning' })).severity, vscode.DiagnosticSeverity.Warning)

--- a/src/test/fixtures/violation.sarif
+++ b/src/test/fixtures/violation.sarif
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "/src/fails.c"
+                },
+                "region": {
+                  "startLine": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "array bounds violated: array `values' upper bound"
+          },
+          "ruleId": "array-bounds-violated",
+          "taxa": [
+            {
+              "id": "121",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            },
+            {
+              "id": "125",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            },
+            {
+              "id": "129",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            },
+            {
+              "id": "131",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            },
+            {
+              "id": "193",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            },
+            {
+              "id": "787",
+              "toolComponent": {
+                "name": "CWE"
+              }
+            }
+          ]
+        }
+      ],
+      "taxonomies": [
+        {
+          "informationUri": "https://cwe.mitre.org/",
+          "name": "CWE",
+          "organization": "MITRE",
+          "shortDescription": {
+            "text": "Common Weakness Enumeration"
+          },
+          "taxa": [
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/121.html",
+              "id": "121",
+              "shortDescription": {
+                "text": "Stack-based Buffer Overflow"
+              }
+            },
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/125.html",
+              "id": "125",
+              "shortDescription": {
+                "text": "Out-of-bounds Read"
+              }
+            },
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/129.html",
+              "id": "129",
+              "shortDescription": {
+                "text": "Improper Validation of Array Index"
+              }
+            },
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/131.html",
+              "id": "131",
+              "shortDescription": {
+                "text": "Incorrect Calculation of Buffer Size"
+              }
+            },
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/193.html",
+              "id": "193",
+              "shortDescription": {
+                "text": "Off-by-one Error"
+              }
+            },
+            {
+              "helpUri": "https://cwe.mitre.org/data/definitions/787.html",
+              "id": "787",
+              "shortDescription": {
+                "text": "Out-of-bounds Write"
+              }
+            }
+          ],
+          "version": "4.20"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://esbmc.org",
+          "name": "ESBMC",
+          "rules": [
+            {
+              "id": "array-bounds-violated",
+              "properties": {
+                "tags": [
+                  "external/cwe/cwe-121",
+                  "external/cwe/cwe-125",
+                  "external/cwe/cwe-129",
+                  "external/cwe/cwe-131",
+                  "external/cwe/cwe-193",
+                  "external/cwe/cwe-787"
+                ]
+              },
+              "shortDescription": {
+                "text": "Array bounds violated"
+              }
+            }
+          ],
+          "version": "8.4.0"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/src/test/package/Languages.test.ts
+++ b/src/test/package/Languages.test.ts
@@ -1,0 +1,62 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as path from 'path'
+import { SUPPORTED_LANGUAGES, SUPPORTED_EXTENSIONS } from '../../languages'
+
+const ROOT = path.resolve(__dirname, '..', '..', '..')
+const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'))
+const activationEvents: string[] = manifest.activationEvents
+
+describe('supported languages', () => {
+  it('lists the languages ESBMC verifies', () => {
+    assert.deepStrictEqual(
+      SUPPORTED_LANGUAGES.map(language => language.id).sort(),
+      ['c', 'cpp', 'python', 'solidity']
+    )
+  })
+
+  // Without an onLanguage event the extension never starts for that language,
+  // so its CodeLens never appears and its commands are not registered.
+  it('activates the extension for every supported language', () => {
+    for (const language of SUPPORTED_LANGUAGES) {
+      assert.ok(
+        activationEvents.includes(`onLanguage:${language.id}`),
+        `${language.id} has no onLanguage activation event`
+      )
+    }
+  })
+
+  // The VS Code language identifier is not the file extension: Python is
+  // "python", not "py", and Solidity is "solidity", not "sol".
+  it('does not confuse a language identifier with a file extension', () => {
+    for (const language of SUPPORTED_LANGUAGES) {
+      if (language.id === 'c' || language.id === 'cpp') {
+        continue
+      }
+      assert.ok(
+        !language.extensions.includes(language.id),
+        `${language.id} looks like a file extension rather than a language id`
+      )
+    }
+  })
+
+  it('verifies every language it activates for', () => {
+    const activated = activationEvents
+      .filter(event => event.startsWith('onLanguage:'))
+      .map(event => event.slice('onLanguage:'.length))
+    for (const id of activated) {
+      assert.ok(
+        SUPPORTED_LANGUAGES.some(language => language.id === id),
+        `the extension activates for ${id} but cannot verify it`
+      )
+    }
+  })
+
+  it('accepts the file extension of every supported language', () => {
+    for (const language of SUPPORTED_LANGUAGES) {
+      for (const extension of language.extensions) {
+        assert.ok(SUPPORTED_EXTENSIONS.has(extension), `.${extension} is not accepted`)
+      }
+    }
+  })
+})

--- a/src/test/package/Languages.test.ts
+++ b/src/test/package/Languages.test.ts
@@ -1,11 +1,23 @@
 import * as assert from 'assert'
 import * as fs from 'fs'
 import * as path from 'path'
-import { SUPPORTED_LANGUAGES, SUPPORTED_EXTENSIONS } from '../../languages'
+import { SUPPORTED_LANGUAGES, SUPPORTED_EXTENSIONS, UNVERIFIABLE_EXTENSIONS } from '../../languages'
 
 const ROOT = path.resolve(__dirname, '..', '..', '..')
 const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'))
 const activationEvents: string[] = manifest.activationEvents
+const contributedLanguages: any[] = manifest.contributes.languages ?? []
+
+// Which extensions VS Code opens under each id we activate for: the built-in
+// c, cpp and python contributions, and the solidity language contributed by
+// this extension. An id activates the extension for every file below, so this
+// is the set run() is answerable for.
+const VS_CODE_EXTENSIONS: Record<string, string[]> = {
+  c: ['c', 'i', 'h'],
+  cpp: ['cpp', 'cc', 'cxx', 'c++', 'hpp', 'hh', 'hxx', 'h++', 'ii'],
+  python: ['py', 'pyi', 'pyw', 'rpy', 'cpy', 'gyp', 'gypi', 'ipy'],
+  solidity: ['sol']
+}
 
 describe('supported languages', () => {
   it('lists the languages ESBMC verifies', () => {
@@ -49,6 +61,43 @@ describe('supported languages', () => {
         SUPPORTED_LANGUAGES.some(language => language.id === id),
         `the extension activates for ${id} but cannot verify it`
       )
+    }
+  })
+
+  // VS Code contributes no solidity language, so without this the activation
+  // event never fires and a .sol file has no language id to match on.
+  it('contributes the solidity language nothing else provides', () => {
+    const solidity = contributedLanguages.find(language => language.id === 'solidity')
+    assert.ok(solidity, 'the manifest contributes no solidity language')
+    assert.deepStrictEqual(solidity.extensions, ['.sol'])
+  })
+
+  // The gap this closes: activating for an id covers every file VS Code opens
+  // under it, and run() then refuses the ones not listed here.
+  it('claims only extensions VS Code maps to that language', () => {
+    for (const language of SUPPORTED_LANGUAGES) {
+      const known = VS_CODE_EXTENSIONS[language.id]
+      assert.ok(known, `no VS Code mapping recorded for ${language.id}`)
+      for (const extension of language.extensions) {
+        assert.ok(known.includes(extension), `VS Code does not open .${extension} as ${language.id}`)
+      }
+    }
+  })
+
+  it('accounts for every extension its languages cover', () => {
+    for (const language of SUPPORTED_LANGUAGES) {
+      for (const extension of VS_CODE_EXTENSIONS[language.id]) {
+        assert.ok(
+          SUPPORTED_EXTENSIONS.has(extension) || UNVERIFIABLE_EXTENSIONS.includes(extension),
+          `.${extension} opens as ${language.id} but is neither verified nor listed as unverifiable`
+        )
+      }
+    }
+  })
+
+  it('accepts no extension it also calls unverifiable', () => {
+    for (const extension of UNVERIFIABLE_EXTENSIONS) {
+      assert.ok(!SUPPORTED_EXTENSIONS.has(extension), `.${extension} is both accepted and unverifiable`)
     }
   })
 

--- a/src/test/parsers/SarifParser.test.ts
+++ b/src/test/parsers/SarifParser.test.ts
@@ -1,0 +1,131 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as path from 'path'
+import { parseSarif, resolveFindingPaths } from '../../parsers/sarifParser'
+
+const FIXTURE = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'fixtures', 'violation.sarif')
+
+// A real report from `esbmc fails.c --sarif-output`, with only the absolute
+// source path made portable.
+const violation = fs.readFileSync(FIXTURE, 'utf8')
+
+function sarif (results: unknown[]): string {
+  return JSON.stringify({ version: '2.1.0', runs: [{ results }] })
+}
+
+describe('parseSarif', () => {
+  it('reads a real ESBMC violation report', () => {
+    const findings = parseSarif(violation)
+    assert.strictEqual(findings.length, 1)
+    assert.deepStrictEqual(findings[0], {
+      file: '/src/fails.c',
+      line: 5,
+      column: undefined,
+      message: "array bounds violated: array `values' upper bound",
+      ruleId: 'array-bounds-violated',
+      severity: 'error',
+      cwes: ['CWE-121', 'CWE-125', 'CWE-129', 'CWE-131', 'CWE-193', 'CWE-787']
+    })
+  })
+
+  // ESBMC writes no report at all when everything holds, but an empty one has
+  // the same meaning: nothing was violated.
+  it('returns nothing for a report with no results', () => {
+    assert.deepStrictEqual(parseSarif(sarif([])), [])
+    assert.deepStrictEqual(parseSarif(JSON.stringify({ version: '2.1.0', runs: [] })), [])
+  })
+
+  it('reports every violated property', () => {
+    const results = [1, 2].map(line => ({
+      level: 'error',
+      message: { text: `failure ${line}` },
+      locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' }, region: { startLine: line } } }]
+    }))
+    assert.deepStrictEqual(parseSarif(sarif(results)).map(f => f.line), [1, 2])
+  })
+
+  it('keeps the column when ESBMC gives one', () => {
+    const [finding] = parseSarif(sarif([{
+      level: 'warning',
+      message: { text: 'x' },
+      locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' }, region: { startLine: 7, startColumn: 9 } } }]
+    }]))
+    assert.strictEqual(finding.line, 7)
+    assert.strictEqual(finding.column, 9)
+    assert.strictEqual(finding.severity, 'warning')
+  })
+
+  it('defaults a missing line to the top of the file', () => {
+    const [finding] = parseSarif(sarif([{
+      message: { text: 'x' },
+      locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' } } }]
+    }]))
+    assert.strictEqual(finding.line, 1)
+  })
+
+  it('treats an unknown or missing level as an error', () => {
+    for (const level of [undefined, 'none', 'nonsense']) {
+      const [finding] = parseSarif(sarif([{
+        level,
+        message: { text: 'x' },
+        locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' }, region: { startLine: 1 } } }]
+      }]))
+      assert.strictEqual(finding.severity, level === 'none' ? 'note' : 'error', `level ${String(level)}`)
+    }
+  })
+
+  it('collects CWE taxa and ignores taxonomies that are not CWE', () => {
+    const [finding] = parseSarif(sarif([{
+      message: { text: 'x' },
+      locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' }, region: { startLine: 1 } } }],
+      taxa: [
+        { id: '787', toolComponent: { name: 'CWE' } },
+        { id: 'RULE-1', toolComponent: { name: 'MISRA' } },
+        { id: '125' }
+      ]
+    }]))
+    assert.deepStrictEqual(finding.cwes, ['CWE-787'])
+  })
+
+  it('strips a file:// prefix from the location', () => {
+    const [finding] = parseSarif(sarif([{
+      message: { text: 'x' },
+      locations: [{ physicalLocation: { artifactLocation: { uri: 'file:///a.c' }, region: { startLine: 1 } } }]
+    }]))
+    assert.strictEqual(finding.file, '/a.c')
+  })
+
+  // A result we cannot place in a file would become a diagnostic with nowhere
+  // to go, so it is dropped rather than pinned to the wrong line.
+  it('drops results with no usable location or message', () => {
+    assert.deepStrictEqual(parseSarif(sarif([
+      { message: { text: 'no locations' } },
+      { message: { text: 'no uri' }, locations: [{ physicalLocation: { region: { startLine: 1 } } }] },
+      { locations: [{ physicalLocation: { artifactLocation: { uri: '/a.c' } } }] }
+    ])), [])
+  })
+
+  it('rejects a report that is not JSON', () => {
+    assert.throws(() => parseSarif('not json'), SyntaxError)
+  })
+})
+
+describe('resolveFindingPaths', () => {
+  it('leaves an absolute path alone', () => {
+    const [finding] = resolveFindingPaths([{ file: '/abs/a.c', line: 1, message: 'x', severity: 'error', cwes: [] }], '/base')
+    assert.strictEqual(finding.file, '/abs/a.c')
+  })
+
+  // ESBMC names an included header the way it was reached, which can be
+  // relative; VS Code would otherwise place the diagnostic on /inc/hdr.h.
+  it('resolves a relative header against the directory ESBMC ran in', () => {
+    const [finding] = resolveFindingPaths([{ file: 'inc/hdr.h', line: 1, message: 'x', severity: 'error', cwes: [] }], '/base')
+    assert.strictEqual(finding.file, path.resolve('/base', 'inc/hdr.h'))
+  })
+
+  it('keeps every other field', () => {
+    const original = { file: 'a.c', line: 4, message: 'x', severity: 'warning' as const, cwes: ['CWE-1'], ruleId: 'r' }
+    const [finding] = resolveFindingPaths([original], '/base')
+    assert.deepStrictEqual({ ...finding, file: original.file }, original)
+  })
+})

--- a/src/test/parsers/SarifPipeline.test.ts
+++ b/src/test/parsers/SarifPipeline.test.ts
@@ -86,4 +86,18 @@ describe('SARIF pipeline against real ESBMC', function () {
     assert.match(result.stdout + result.stderr, /VERIFICATION FAILED/)
     assert.strictEqual(fs.existsSync(report), false)
   })
+
+  // Issue #12: the same SARIF pipeline has to work for the non-C languages,
+  // since diagnostics are what makes them usable in the editor.
+  it('produces a finding for a Python program', async () => {
+    const file = path.join(dir, 'fails.py')
+    const report = path.join(dir, 'fails-py.sarif')
+    fs.writeFileSync(file, 'values = [0, 1, 2, 3]\nassert values[0] == 1\n')
+    const result = await runShellCommand(`esbmc "${file}" --sarif-output "${report}"`)
+    assert.match(result.stdout + result.stderr, /VERIFICATION FAILED/)
+    const findings = parseSarif(fs.readFileSync(report, 'utf8'))
+    assert.ok(findings.length > 0, 'no findings for the Python program')
+    assert.strictEqual(findings[0].file, file)
+    assert.strictEqual(findings[0].line, 2)
+  })
 })

--- a/src/test/parsers/SarifPipeline.test.ts
+++ b/src/test/parsers/SarifPipeline.test.ts
@@ -14,6 +14,17 @@ const FAILS = `int main(void)
 }
 `
 
+const SOLIDITY_FAILS = `// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.5.0;
+
+contract Simple {
+    function f() public pure {
+        uint8 x = 1;
+        assert(x == 2);
+    }
+}
+`
+
 const PASSES = `int main(void)
 {
   int values[4];
@@ -99,5 +110,25 @@ describe('SARIF pipeline against real ESBMC', function () {
     assert.ok(findings.length > 0, 'no findings for the Python program')
     assert.strictEqual(findings[0].file, file)
     assert.strictEqual(findings[0].line, 2)
+  })
+
+  // Solidity needs solc to reach an AST, and ESBMC's Solidity model spins in
+  // an address loop until the unwind is bounded. Both are why this is the one
+  // language the extension supports that cannot be checked unconditionally.
+  it('produces a finding for a Solidity contract', async function () {
+    const file = path.join(dir, 'fails.sol')
+    const report = path.join(dir, 'fails-sol.sarif')
+    fs.writeFileSync(file, SOLIDITY_FAILS)
+    const result = await runShellCommand(
+      `esbmc "${file}" --unwind 2 --no-unwinding-assertions --sarif-output "${report}"`)
+    const transcript = result.stdout + result.stderr
+    if (/solc not found/.test(transcript)) {
+      return this.skip()
+    }
+    assert.match(transcript, /VERIFICATION FAILED/)
+    const findings = parseSarif(fs.readFileSync(report, 'utf8'))
+    assert.ok(findings.length > 0, 'no findings for the Solidity contract')
+    assert.strictEqual(findings[0].file, file)
+    assert.strictEqual(findings[0].line, 7, 'the failing assertion is on line 7')
   })
 })

--- a/src/test/parsers/SarifPipeline.test.ts
+++ b/src/test/parsers/SarifPipeline.test.ts
@@ -1,0 +1,89 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { parseSarif } from '../../parsers/sarifParser'
+import { runShellCommand } from '../../utils/commands'
+
+const FAILS = `int main(void)
+{
+  int values[4];
+  for (int i = 0; i <= 4; i++)
+    values[i] = i;
+  return 0;
+}
+`
+
+const PASSES = `int main(void)
+{
+  int values[4];
+  for (int i = 0; i < 4; i++)
+    values[i] = i;
+  return values[0];
+}
+`
+
+async function esbmcAvailable (): Promise<boolean> {
+  return (await runShellCommand('esbmc --version')).code === 0
+}
+
+// Proves the SARIF contract against the real tool rather than a fixture.
+// Skipped where ESBMC is not installed, which includes CI.
+describe('SARIF pipeline against real ESBMC', function () {
+  this.timeout(120000)
+
+  let dir: string
+
+  before(async function () {
+    if (!await esbmcAvailable()) {
+      this.skip()
+    }
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-sarif-'))
+  })
+
+  after(() => {
+    if (dir !== undefined) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  async function verify (source: string, name: string) {
+    const file = path.join(dir, `${name}.c`)
+    const report = path.join(dir, `${name}.sarif`)
+    fs.writeFileSync(file, source)
+    const result = await runShellCommand(`esbmc "${file}" --sarif-output "${report}"`)
+    // ESBMC prints its verdict on stderr, not stdout.
+    return { file, report, transcript: result.stdout + result.stderr }
+  }
+
+  it('turns a violation into a finding on the right line', async () => {
+    const { file, report, transcript } = await verify(FAILS, 'fails')
+    assert.match(transcript, /VERIFICATION FAILED/)
+    const findings = parseSarif(fs.readFileSync(report, 'utf8'))
+    assert.strictEqual(findings.length, 1)
+    assert.strictEqual(findings[0].file, file)
+    assert.strictEqual(findings[0].line, 5, 'the out-of-bounds write is on line 5')
+    assert.strictEqual(findings[0].severity, 'error')
+    assert.match(findings[0].message, /array bounds/)
+    assert.ok(findings[0].cwes.length > 0, 'ESBMC reports CWEs for this property')
+  })
+
+  // ESBMC writes no report when nothing is violated, which is why run() treats
+  // a missing report as "no findings" rather than an error.
+  it('writes no report when every property holds', async () => {
+    const { report, transcript } = await verify(PASSES, 'passes')
+    assert.match(transcript, /VERIFICATION SUCCESSFUL/)
+    assert.strictEqual(fs.existsSync(report), false)
+  })
+
+  // run() has a "failed, see output" verdict solely because of this: with
+  // --multi-property ESBMC reports every violation but writes no SARIF at all.
+  it('writes no report under --multi-property, even on failure', async () => {
+    const file = path.join(dir, 'multi.c')
+    const report = path.join(dir, 'multi.sarif')
+    fs.writeFileSync(file, FAILS)
+    const result = await runShellCommand(`esbmc "${file}" --multi-property --sarif-output "${report}"`)
+    assert.match(result.stdout + result.stderr, /VERIFICATION FAILED/)
+    assert.strictEqual(fs.existsSync(report), false)
+  })
+})

--- a/src/test/parsers/Verdict.test.ts
+++ b/src/test/parsers/Verdict.test.ts
@@ -1,0 +1,78 @@
+import * as assert from 'assert'
+import { classifyVerdict, statusText, RunOutcome } from '../../parsers/verdict'
+import { EsbmcFinding } from '../../parsers/sarifParser'
+
+function finding (): EsbmcFinding {
+  return { file: '/a.c', line: 1, message: 'x', severity: 'error', cwes: [] }
+}
+
+function outcome (overrides: Partial<RunOutcome> = {}): RunOutcome {
+  return { transcript: '', findings: [], timedOut: false, timeoutSeconds: 60, ...overrides }
+}
+
+describe('classifyVerdict', () => {
+  it('reports a timeout ahead of anything else in the transcript', () => {
+    const verdict = classifyVerdict(outcome({
+      timedOut: true,
+      timeoutSeconds: 5,
+      transcript: 'VERIFICATION SUCCESSFUL',
+      findings: [finding()]
+    }))
+    assert.deepStrictEqual(verdict, { kind: 'timeout', seconds: 5 })
+  })
+
+  it('reports the number of violated properties', () => {
+    assert.deepStrictEqual(
+      classifyVerdict(outcome({ findings: [finding(), finding()], transcript: 'VERIFICATION FAILED' })),
+      { kind: 'violations', count: 2 }
+    )
+  })
+
+  it('reports success when nothing was violated', () => {
+    assert.deepStrictEqual(
+      classifyVerdict(outcome({ transcript: 'VERIFICATION SUCCESSFUL' })),
+      { kind: 'success' }
+    )
+  })
+
+  // ESBMC writes no SARIF report under --multi-property, so a run can fail
+  // with nothing to place against a line.
+  it('reports a failure that produced no findings', () => {
+    assert.deepStrictEqual(
+      classifyVerdict(outcome({ transcript: 'VERIFICATION FAILED' })),
+      { kind: 'failed-without-findings' }
+    )
+  })
+
+  it('reports no verdict when ESBMC never reached one', () => {
+    assert.deepStrictEqual(
+      classifyVerdict(outcome({ transcript: 'error: no such file' })),
+      { kind: 'unknown' }
+    )
+  })
+})
+
+describe('statusText', () => {
+  it('agrees with the number of properties', () => {
+    assert.match(statusText({ kind: 'violations', count: 1 }), /1 property violated/)
+    assert.match(statusText({ kind: 'violations', count: 3 }), /3 properties violated/)
+  })
+
+  it('names the timeout that fired', () => {
+    assert.match(statusText({ kind: 'timeout', seconds: 30 }), /timed out after 30s/)
+  })
+
+  it('gives every verdict its own text', () => {
+    const texts = [
+      statusText({ kind: 'success' }),
+      statusText({ kind: 'failed-without-findings' }),
+      statusText({ kind: 'unknown' }),
+      statusText({ kind: 'violations', count: 1 }),
+      statusText({ kind: 'timeout', seconds: 1 })
+    ]
+    assert.strictEqual(new Set(texts).size, texts.length)
+    for (const text of texts) {
+      assert.match(text, /^\$\([a-z~-]+\) ESBMC: /)
+    }
+  })
+})

--- a/src/test/utils/commands.test.ts
+++ b/src/test/utils/commands.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { executeShellCommand } from '../../utils/commands'
+import { executeShellCommand, runShellCommand } from '../../utils/commands'
 
 describe('executeShellCommand', () => {
   it('resolves with the command stdout', async () => {
@@ -25,5 +25,50 @@ describe('executeShellCommand', () => {
 
   it('rejects when the command does not exist', async () => {
     await assert.rejects(executeShellCommand('esbmc-no-such-executable'))
+  })
+})
+
+describe('runShellCommand', function () {
+  this.timeout(60000)
+
+  it('captures stdout and the exit code of a successful command', async () => {
+    const result = await runShellCommand('node -e "console.log(1)"')
+    assert.strictEqual(result.stdout.trim(), '1')
+    assert.strictEqual(result.code, 0)
+    assert.strictEqual(result.timedOut, false)
+  })
+
+  // ESBMC exits non-zero when it finds a violation, which is a result rather
+  // than an error, so a failing command must resolve instead of rejecting.
+  it('resolves rather than rejects when the command exits non-zero', async () => {
+    const result = await runShellCommand('node -e "console.error(7); process.exit(3)"')
+    assert.strictEqual(result.code, 3)
+    assert.match(result.stderr, /7/)
+    assert.strictEqual(result.timedOut, false)
+  })
+
+  it('kills a command that outlives the timeout', async () => {
+    const started = Date.now()
+    const result = await runShellCommand('node -e "setTimeout(() => {}, 60000)"', { timeoutMs: 500 })
+    assert.strictEqual(result.timedOut, true)
+    assert.ok(Date.now() - started < 30000, 'the timeout did not kill the command')
+  })
+
+  it('waits for a slow command when the timeout is zero', async () => {
+    const result = await runShellCommand('node -e "setTimeout(() => console.log(9), 300)"', { timeoutMs: 0 })
+    assert.strictEqual(result.timedOut, false)
+    assert.match(result.stdout, /9/)
+  })
+
+  // Decoding each chunk separately mangles a multi-byte character that
+  // straddles a chunk boundary, which ESBMC output hits on long traces.
+  it('decodes multi-byte output split across chunks', async () => {
+    const result = await runShellCommand(
+      // The leading byte makes every following 2-byte character straddle an
+      // odd offset, so one lands across a 64KB chunk boundary.
+      'node -e "process.stdout.write(String.fromCodePoint(0x78) + String.fromCodePoint(0x00e9).repeat(200000))"'
+    )
+    assert.strictEqual(result.stdout.length, 200001)
+    assert.strictEqual(result.stdout.includes(String.fromCodePoint(0xfffd)), false, 'replacement characters appeared')
   })
 })

--- a/src/test/utils/esbmcPath.test.ts
+++ b/src/test/utils/esbmcPath.test.ts
@@ -1,0 +1,98 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { installedBinary, legacyBinary, resolveEsbmc, setStorageRoot } from '../../utils/esbmcPath'
+
+function restoreEnv (key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+/** A script that answers `--version`, so PATH lookup finds something runnable. */
+function writeFakeEsbmc (file: string) {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, '#!/bin/sh\necho "ESBMC version 1.2.3"\n')
+  fs.chmodSync(file, 0o755)
+}
+
+// The resolver decides which binary both verification and the version report
+// use, so its order is the difference between reporting one ESBMC and running
+// another. sh-only, matching the fake binaries it plants.
+describe('resolveEsbmc', function () {
+  this.timeout(30000)
+
+  let home: string
+  let storage: string
+  let onPath: string
+  let originalHome: string | undefined
+  let originalPath: string | undefined
+
+  before(function () {
+    if (process.platform === 'win32') {
+      this.skip()
+    }
+  })
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-esbmc-home-'))
+    storage = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-esbmc-store-'))
+    onPath = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-esbmc-path-'))
+    originalHome = process.env.HOME
+    originalPath = process.env.PATH
+    process.env.HOME = home
+    // Keep a real ESBMC on the developer's PATH out of the way.
+    process.env.PATH = onPath
+    setStorageRoot(storage)
+  })
+
+  afterEach(() => {
+    restoreEnv('HOME', originalHome)
+    restoreEnv('PATH', originalPath)
+    for (const dir of [home, storage, onPath]) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reports nothing when ESBMC is nowhere', async () => {
+    assert.strictEqual(await resolveEsbmc('linux'), undefined)
+  })
+
+  it('prefers the ESBMC on PATH, which is the user\'s own', async () => {
+    writeFakeEsbmc(path.join(onPath, 'esbmc'))
+    writeFakeEsbmc(installedBinary('linux') as string)
+    writeFakeEsbmc(legacyBinary('linux'))
+
+    assert.deepStrictEqual(await resolveEsbmc('linux'), { command: 'esbmc', source: 'path' })
+  })
+
+  it('falls back to the install it manages', async () => {
+    const installed = installedBinary('linux') as string
+    writeFakeEsbmc(installed)
+    writeFakeEsbmc(legacyBinary('linux'))
+
+    const resolved = await resolveEsbmc('linux')
+    assert.strictEqual(resolved?.source, 'installed')
+    assert.ok(resolved?.command.includes(installed), resolved?.command)
+  })
+
+  it('falls back to a pre-installer install last', async () => {
+    const legacy = legacyBinary('linux')
+    writeFakeEsbmc(legacy)
+
+    const resolved = await resolveEsbmc('linux')
+    assert.strictEqual(resolved?.source, 'legacy')
+    assert.ok(resolved?.command.includes(legacy), resolved?.command)
+  })
+
+  it('quotes the path it reports, which the storage path can need', async () => {
+    setStorageRoot(path.join(storage, 'a dir'))
+    writeFakeEsbmc(installedBinary('linux') as string)
+
+    const resolved = await resolveEsbmc('linux')
+    assert.match(resolved?.command ?? '', /^'.*'$/)
+  })
+})

--- a/src/test/utils/platform.test.ts
+++ b/src/test/utils/platform.test.ts
@@ -1,0 +1,78 @@
+import * as assert from 'assert'
+import * as path from 'path'
+import {
+  assetForPlatform,
+  binaryName,
+  binaryPath,
+  extractCommand,
+  isSupportedPlatform
+} from '../../utils/platform'
+
+// Asset names verified against the esbmc/esbmc releases API: every release
+// publishes esbmc-linux.zip, esbmc-macos.zip and esbmc-windows.zip.
+describe('assetForPlatform', () => {
+  it('maps each platform to the asset ESBMC publishes', () => {
+    assert.strictEqual(assetForPlatform('linux'), 'esbmc-linux.zip')
+    assert.strictEqual(assetForPlatform('darwin'), 'esbmc-macos.zip')
+    assert.strictEqual(assetForPlatform('win32'), 'esbmc-windows.zip')
+  })
+
+  it('refuses a platform with no published build', () => {
+    assert.strictEqual(isSupportedPlatform('freebsd'), false)
+    assert.throws(() => assetForPlatform('freebsd'), /freebsd/)
+  })
+
+  it('accepts the three platforms ESBMC builds for', () => {
+    for (const platform of ['linux', 'darwin', 'win32']) {
+      assert.ok(isSupportedPlatform(platform), platform)
+    }
+  })
+})
+
+describe('binaryPath', () => {
+  it('names the Windows executable with its extension', () => {
+    assert.strictEqual(binaryName('win32'), 'esbmc.exe')
+    assert.strictEqual(binaryName('linux'), 'esbmc')
+    assert.strictEqual(binaryName('darwin'), 'esbmc')
+  })
+
+  // The archives ship bin/esbmc alongside bin/libz3.dll on Windows, so the
+  // binary has to stay inside bin/ rather than be lifted out of it.
+  it('keeps the binary inside the archive bin directory', () => {
+    assert.strictEqual(binaryPath('/store/esbmc', 'linux'), path.join('/store/esbmc', 'bin', 'esbmc'))
+    assert.strictEqual(binaryPath('/store/esbmc', 'win32'), path.join('/store/esbmc', 'bin', 'esbmc.exe'))
+  })
+})
+
+describe('extractCommand', () => {
+  it('uses PowerShell on Windows, which has no unzip', () => {
+    const cmd = extractCommand('C:\\tmp\\e.zip', 'C:\\store', 'win32')
+    assert.match(cmd, /^powershell /)
+    assert.match(cmd, /Expand-Archive/)
+    assert.ok(cmd.includes("'C:\\tmp\\e.zip'"), cmd)
+    assert.ok(cmd.includes("'C:\\store'"), cmd)
+  })
+
+  it('doubles a quote inside a PowerShell literal', () => {
+    const cmd = extractCommand("/tmp/it's.zip", '/store', 'win32')
+    assert.ok(cmd.includes("'/tmp/it''s.zip'"), cmd)
+  })
+
+  it('uses unzip elsewhere', () => {
+    for (const platform of ['linux', 'darwin']) {
+      const cmd = extractCommand('/tmp/e.zip', '/store', platform)
+      assert.match(cmd, /^unzip -o /)
+      assert.match(cmd, /-d /)
+    }
+  })
+
+  // A download path is attacker-influenced only via the asset name, but the
+  // destination comes from the extension's own storage path, which can contain
+  // anything the user's account name does.
+  it('quotes paths so a shell cannot reinterpret them', () => {
+    const cmd = extractCommand('/tmp/$(touch pwned).zip', '/store dir', 'linux')
+    assert.ok(!cmd.includes('$(touch pwned).zip"'), cmd)
+    assert.ok(cmd.includes("'/tmp/$(touch pwned).zip'"), cmd)
+    assert.ok(cmd.includes("'/store dir'"), cmd)
+  })
+})

--- a/src/test/utils/platform.test.ts
+++ b/src/test/utils/platform.test.ts
@@ -46,33 +46,38 @@ describe('binaryPath', () => {
 
 describe('extractCommand', () => {
   it('uses PowerShell on Windows, which has no unzip', () => {
-    const cmd = extractCommand('C:\\tmp\\e.zip', 'C:\\store', 'win32')
-    assert.match(cmd, /^powershell /)
-    assert.match(cmd, /Expand-Archive/)
-    assert.ok(cmd.includes("'C:\\tmp\\e.zip'"), cmd)
-    assert.ok(cmd.includes("'C:\\store'"), cmd)
+    const { file, args } = extractCommand('C:\\tmp\\e.zip', 'C:\\store', 'win32')
+    assert.strictEqual(file, 'powershell')
+    const script = args[args.length - 1]
+    assert.match(script, /^Expand-Archive /)
+    assert.ok(script.includes("'C:\\tmp\\e.zip'"), script)
+    assert.ok(script.includes("'C:\\store'"), script)
   })
 
   it('doubles a quote inside a PowerShell literal', () => {
-    const cmd = extractCommand("/tmp/it's.zip", '/store', 'win32')
-    assert.ok(cmd.includes("'/tmp/it''s.zip'"), cmd)
+    const { args } = extractCommand("/tmp/it's.zip", '/store', 'win32')
+    assert.ok(args[args.length - 1].includes("'/tmp/it''s.zip'"), args.join(' '))
   })
 
   it('uses unzip elsewhere', () => {
     for (const platform of ['linux', 'darwin']) {
-      const cmd = extractCommand('/tmp/e.zip', '/store', platform)
-      assert.match(cmd, /^unzip -o /)
-      assert.match(cmd, /-d /)
+      const { file, args } = extractCommand('/tmp/e.zip', '/store', platform)
+      assert.strictEqual(file, 'unzip')
+      assert.deepStrictEqual(args, ['-o', '/tmp/e.zip', '-d', '/store'])
     }
   })
 
-  // A download path is attacker-influenced only via the asset name, but the
-  // destination comes from the extension's own storage path, which can contain
-  // anything the user's account name does.
-  it('quotes paths so a shell cannot reinterpret them', () => {
-    const cmd = extractCommand('/tmp/$(touch pwned).zip', '/store dir', 'linux')
-    assert.ok(!cmd.includes('$(touch pwned).zip"'), cmd)
-    assert.ok(cmd.includes("'/tmp/$(touch pwned).zip'"), cmd)
-    assert.ok(cmd.includes("'/store dir'"), cmd)
+  // The destination comes from the extension's own storage path, which can
+  // contain anything the user's account name does. Nothing quotes a `%` out of
+  // cmd.exe's reach, so no shell is used and each path stays one argument.
+  it('hands paths over as arguments rather than as a command line', () => {
+    const { args } = extractCommand('/tmp/$(touch pwned).zip', '/store %USERNAME% dir', 'linux')
+    assert.ok(args.includes('/tmp/$(touch pwned).zip'), args.join(' '))
+    assert.ok(args.includes('/store %USERNAME% dir'), args.join(' '))
+  })
+
+  it('leaves a percent in a Windows path untouched', () => {
+    const { args } = extractCommand('C:\\tmp\\e.zip', 'C:\\store\\100%%\\esbmc', 'win32')
+    assert.ok(args[args.length - 1].includes("'C:\\store\\100%%\\esbmc'"), args.join(' '))
   })
 })

--- a/src/test/utils/quoteShellArg.test.ts
+++ b/src/test/utils/quoteShellArg.test.ts
@@ -4,6 +4,25 @@ import * as os from 'os'
 import * as path from 'path'
 import { quoteShellArg, runShellCommand } from '../../utils/commands'
 
+// Quoting must follow the platform it is asked about, not the one the tests
+// run on: extractCommand builds a Linux unzip command on any host.
+describe('quoteShellArg across platforms', () => {
+  it('uses POSIX quoting when asked for a POSIX platform', () => {
+    for (const platform of ['linux', 'darwin']) {
+      assert.strictEqual(quoteShellArg('/a b.c', platform), "'/a b.c'")
+      assert.strictEqual(quoteShellArg('$(id)', platform), "'$(id)'")
+    }
+  })
+
+  it('uses Windows quoting when asked for win32', () => {
+    assert.strictEqual(quoteShellArg('C:\\a b.c', 'win32'), '"C:\\a b.c"')
+  })
+
+  it('escapes an embedded single quote for POSIX', () => {
+    assert.strictEqual(quoteShellArg("it's", 'linux'), "'it'\\''s'")
+  })
+})
+
 // Double quotes do not stop command substitution on POSIX, so a file name is
 // an injection vector wherever it reaches a shell. verifyOnSave makes that
 // reachable by saving a file in a hostile checkout.

--- a/src/test/utils/quoteShellArg.test.ts
+++ b/src/test/utils/quoteShellArg.test.ts
@@ -51,3 +51,49 @@ describe('quoteShellArg', function () {
     assert.strictEqual(result.stdout, '$(echo hi)')
   })
 })
+
+// The POSIX suite above skips on Windows, which left the branch that rewrites
+// its input as the only one with no coverage at all. These run everywhere by
+// driving the win32 branch directly.
+describe('quoteShellArg on Windows', () => {
+  const original = process.platform
+
+  function asWin32 (run: () => void) {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      run()
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  }
+
+  it('wraps a path in double quotes', () => {
+    asWin32(() => {
+      assert.strictEqual(quoteShellArg('C:\\Program Files\\a.c'), '"C:\\Program Files\\a.c"')
+    })
+  })
+
+  it('leaves a path alone but for the quotes', () => {
+    asWin32(() => {
+      for (const value of ['a.c', 'C:\\x\\y.c', 'with space.c', 'a&b.c', 'semi;colon.c', '$(id).c']) {
+        assert.strictEqual(quoteShellArg(value), `"${value}"`)
+      }
+    })
+  })
+
+  // cmd.exe expands %VAR% inside double quotes and offers no escape for it, so
+  // quoting a path containing one would name a different file.
+  it('refuses a path cmd.exe would rewrite rather than corrupting it', () => {
+    asWin32(() => {
+      assert.throws(() => quoteShellArg('C:\\100%\\a.c'), /cannot be passed a path containing %/)
+      assert.throws(() => quoteShellArg('C:\\%USERNAME%\\a.c'), /%/)
+      assert.throws(() => quoteShellArg('C:\\a"b\\c.c'), /cannot be passed a path containing "/)
+    })
+  })
+
+  it('names the path it refused', () => {
+    asWin32(() => {
+      assert.throws(() => quoteShellArg('C:\\100%\\a.c'), /C:\\100%\\a\.c/)
+    })
+  })
+})

--- a/src/test/utils/quoteShellArg.test.ts
+++ b/src/test/utils/quoteShellArg.test.ts
@@ -1,0 +1,53 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { quoteShellArg, runShellCommand } from '../../utils/commands'
+
+// Double quotes do not stop command substitution on POSIX, so a file name is
+// an injection vector wherever it reaches a shell. verifyOnSave makes that
+// reachable by saving a file in a hostile checkout.
+describe('quoteShellArg', function () {
+  this.timeout(60000)
+
+  let dir: string
+
+  before(function () {
+    if (process.platform === 'win32') {
+      this.skip()
+    }
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-quote-'))
+  })
+
+  after(() => {
+    if (dir !== undefined) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('stops command substitution in a file name', async () => {
+    const marker = path.join(dir, 'pwned')
+    const hostile = path.join(dir, `$(touch ${marker})x.c`)
+    await runShellCommand(`echo ${quoteShellArg(hostile)}`)
+    assert.strictEqual(fs.existsSync(marker), false, 'the substituted command ran')
+  })
+
+  it('stops backtick substitution in a file name', async () => {
+    const marker = path.join(dir, 'pwned-backtick')
+    const hostile = path.join(dir, '`touch ' + marker + '`x.c')
+    await runShellCommand(`echo ${quoteShellArg(hostile)}`)
+    assert.strictEqual(fs.existsSync(marker), false, 'the substituted command ran')
+  })
+
+  it('passes the value through unchanged', async () => {
+    for (const value of ['plain.c', 'with space.c', "it's.c", 'semi;colon.c', '$HOME.c', 'a&b|c.c']) {
+      const result = await runShellCommand(`printf %s ${quoteShellArg(value)}`)
+      assert.strictEqual(result.stdout, value)
+    }
+  })
+
+  it('leaves a command substitution intact as literal text', async () => {
+    const result = await runShellCommand(`printf %s ${quoteShellArg('$(echo hi)')}`)
+    assert.strictEqual(result.stdout, '$(echo hi)')
+  })
+})

--- a/src/test/utils/versions.test.ts
+++ b/src/test/utils/versions.test.ts
@@ -66,12 +66,13 @@ describe('getInstalledVersion', function () {
     assert.strictEqual(await getInstalledVersion(), '7.9.0')
   })
 
-  it('prefers $HOME/bin/esbmc over the one on PATH', async () => {
+  // A user's own ESBMC wins over one this extension installed for them.
+  it('prefers the ESBMC on PATH over a legacy $HOME/bin install', async () => {
     const dir = path.join(home, 'pathbin')
     fakeEsbmc(dir, 'ESBMC version 7.9.0')
     fakeEsbmc(path.join(home, 'bin'), 'ESBMC version 7.6.1')
     process.env.PATH = dir
-    assert.strictEqual(await getInstalledVersion(), '7.6.1')
+    assert.strictEqual(await getInstalledVersion(), '7.9.0')
   })
 
   it('returns undefined when ESBMC is not installed', async () => {

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -18,3 +18,96 @@ export async function executeShellCommand (cmd: string): Promise<string> {
     })
   })
 }
+
+/**
+ * Quotes a value so a shell treats it as one literal argument.
+ *
+ * Double quotes are not enough on POSIX: `$(...)` and backticks still expand
+ * inside them, so a file named `$(rm -rf ~)x.c` would run its own command.
+ * `cmd.exe` has no such substitution, and leaves the metacharacters it does
+ * have alone inside double quotes.
+ */
+export function quoteShellArg (value: string): string {
+  if (process.platform === 'win32') {
+    return `"${value.replace(/"/g, '')}"`
+  }
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+export interface CommandResult {
+  stdout: string
+  stderr: string
+  code: number | null
+  timedOut: boolean
+}
+
+export interface RunOptions {
+  /** Kill the command after this long; 0 waits indefinitely. */
+  timeoutMs?: number
+  /** Receives a kill function as soon as the command starts. */
+  onStart?: (kill: () => void) => void
+}
+
+function killTree (pid: number | undefined): void {
+  if (pid === undefined) { return }
+  try {
+    if (process.platform === 'win32') {
+      cp.exec(`taskkill /pid ${pid} /T /F`)
+    } else {
+      process.kill(-pid, 'SIGKILL')
+    }
+  } catch {
+    // The command finished on its own between the kill being asked for and
+    // this call.
+  }
+}
+
+/**
+ * Runs a shell command to completion, capturing its output instead of
+ * rejecting on a non-zero exit. ESBMC exits non-zero when it finds a
+ * violation, which is a result rather than an error.
+ */
+export async function runShellCommand (cmd: string, options: RunOptions = {}): Promise<CommandResult> {
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? Math.max(0, options.timeoutMs as number) : 0
+  return new Promise<CommandResult>(resolve => {
+    // Detached so the shell leads its own process group: killing the shell
+    // alone leaves the command running and its pipes open, so the run never
+    // finishes.
+    const detached = process.platform !== 'win32'
+    const child = cp.spawn(cmd, { shell: true, detached })
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    let settled = false
+
+    // Decode per stream, not per chunk: a multi-byte character split across a
+    // chunk boundary would otherwise be mangled.
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+
+    const timer = timeoutMs > 0
+      ? setTimeout(() => {
+        // Defensive: clearTimeout normally wins, but a callback already queued
+        // when the command exits would otherwise signal a recycled pid.
+        if (settled) { return }
+        timedOut = true
+        killTree(child.pid)
+      }, timeoutMs)
+      : undefined
+
+    options.onStart?.(() => killTree(child.pid))
+
+    child.stdout?.on('data', chunk => { stdout += chunk })
+    child.stderr?.on('data', chunk => { stderr += chunk })
+    child.on('error', error => {
+      settled = true
+      clearTimeout(timer)
+      resolve({ stdout, stderr: stderr + String(error), code: null, timedOut })
+    })
+    child.on('close', code => {
+      settled = true
+      clearTimeout(timer)
+      resolve({ stdout, stderr, code, timedOut })
+    })
+  })
+}

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -19,17 +19,29 @@ export async function executeShellCommand (cmd: string): Promise<string> {
   })
 }
 
+/** Legal in a Windows path, and not expressible as one cmd.exe argument. */
+const UNQUOTABLE_ON_WINDOWS = /["%]/
+
 /**
  * Quotes a value so a shell treats it as one literal argument.
  *
  * Double quotes are not enough on POSIX: `$(...)` and backticks still expand
  * inside them, so a file named `$(rm -rf ~)x.c` would run its own command.
- * `cmd.exe` has no such substitution, and leaves the metacharacters it does
- * have alone inside double quotes.
+ *
+ * `cmd.exe` has no command substitution, but it does expand `%VAR%` inside
+ * double quotes, and a command line offers no escape for either `%` or `"`.
+ * Both are legal in a Windows path, so such a value is refused: quoting it
+ * anyway would run ESBMC against a different file than the one asked for.
+ *
+ * @throws when a Windows path cannot be expressed as one cmd.exe argument.
  */
 export function quoteShellArg (value: string): string {
   if (process.platform === 'win32') {
-    return `"${value.replace(/"/g, '')}"`
+    const unquotable = UNQUOTABLE_ON_WINDOWS.exec(value)
+    if (unquotable !== null) {
+      throw Error(`cmd.exe cannot be passed a path containing ${unquotable[0]}: ${value}`)
+    }
+    return `"${value}"`
   }
   return `'${value.replace(/'/g, "'\\''")}'`
 }

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -68,13 +68,34 @@ function killTree (pid: number | undefined): void {
  * violation, which is a result rather than an error.
  */
 export async function runShellCommand (cmd: string, options: RunOptions = {}): Promise<CommandResult> {
+  return capture(detached => cp.spawn(cmd, { shell: true, detached }), options)
+}
+
+/**
+ * Runs a program directly, with no shell between the arguments and it.
+ *
+ * On Windows a shell command goes through `cmd.exe`, which substitutes
+ * `%VAR%` before the program is started, so an argument holding a legal `%`
+ * arrives rewritten. Nothing quotes its way out of that.
+ */
+export async function runProcess (
+  file: string,
+  args: string[],
+  options: RunOptions = {}
+): Promise<CommandResult> {
+  return capture(detached => cp.spawn(file, args, { detached }), options)
+}
+
+function capture (
+  spawn: (detached: boolean) => cp.ChildProcess,
+  options: RunOptions
+): Promise<CommandResult> {
   const timeoutMs = Number.isFinite(options.timeoutMs) ? Math.max(0, options.timeoutMs as number) : 0
   return new Promise<CommandResult>(resolve => {
-    // Detached so the shell leads its own process group: killing the shell
+    // Detached so the child leads its own process group: killing the shell
     // alone leaves the command running and its pipes open, so the run never
     // finishes.
-    const detached = process.platform !== 'win32'
-    const child = cp.spawn(cmd, { shell: true, detached })
+    const child = spawn(process.platform !== 'win32')
     let stdout = ''
     let stderr = ''
     let timedOut = false

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -27,8 +27,8 @@ export async function executeShellCommand (cmd: string): Promise<string> {
  * `cmd.exe` has no such substitution, and leaves the metacharacters it does
  * have alone inside double quotes.
  */
-export function quoteShellArg (value: string): string {
-  if (process.platform === 'win32') {
+export function quoteShellArg (value: string, platform: string = process.platform): string {
+  if (platform === 'win32') {
     return `"${value.replace(/"/g, '')}"`
   }
   return `'${value.replace(/'/g, "'\\''")}'`

--- a/src/utils/esbmcPath.ts
+++ b/src/utils/esbmcPath.ts
@@ -1,0 +1,51 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { executeShellCommand, quoteShellArg } from './commands'
+import { binaryName, binaryPath } from './platform'
+
+let storageRoot: string | undefined
+
+/** Called once at activation, since only the extension context knows this. */
+export function setStorageRoot (root: string): void {
+  storageRoot = root
+}
+
+export function installDir (): string | undefined {
+  return storageRoot === undefined ? undefined : path.join(storageRoot, 'esbmc')
+}
+
+/** Where the auto-installer puts ESBMC, if the extension has been activated. */
+export function installedBinary (platform: string = process.platform): string | undefined {
+  const dir = installDir()
+  return dir === undefined ? undefined : binaryPath(dir, platform)
+}
+
+/** Where releases before the cross-platform installer put it. */
+export function legacyBinary (platform: string = process.platform): string {
+  return path.join(os.homedir(), 'bin', binaryName(platform))
+}
+
+/**
+ * The ESBMC command to run, already quoted for a shell.
+ *
+ * One resolver for the whole extension: reporting a version from one binary
+ * while verifying with another is worse than not reporting one at all. A
+ * user's own ESBMC wins over the one this extension installed.
+ *
+ * @returns undefined when ESBMC cannot be found anywhere.
+ */
+export async function resolveEsbmcCommand (platform: string = process.platform): Promise<string | undefined> {
+  try {
+    await executeShellCommand('esbmc --version')
+    return 'esbmc'
+  } catch {
+    // Not on PATH; fall through to the locations we manage.
+  }
+  for (const candidate of [installedBinary(platform), legacyBinary(platform)]) {
+    if (candidate !== undefined && fs.existsSync(candidate)) {
+      return quoteShellArg(candidate)
+    }
+  }
+  return undefined
+}

--- a/src/utils/esbmcPath.ts
+++ b/src/utils/esbmcPath.ts
@@ -26,8 +26,17 @@ export function legacyBinary (platform: string = process.platform): string {
   return path.join(os.homedir(), 'bin', binaryName(platform))
 }
 
+/** Where the ESBMC that will run came from. Only `installed` is ours to replace. */
+export type EsbmcSource = 'path' | 'installed' | 'legacy'
+
+export interface ResolvedEsbmc {
+  /** Already quoted for a shell. */
+  command: string
+  source: EsbmcSource
+}
+
 /**
- * The ESBMC command to run, already quoted for a shell.
+ * The ESBMC that will run, and where it came from.
  *
  * One resolver for the whole extension: reporting a version from one binary
  * while verifying with another is worse than not reporting one at all. A
@@ -35,17 +44,26 @@ export function legacyBinary (platform: string = process.platform): string {
  *
  * @returns undefined when ESBMC cannot be found anywhere.
  */
-export async function resolveEsbmcCommand (platform: string = process.platform): Promise<string | undefined> {
+export async function resolveEsbmc (platform: string = process.platform): Promise<ResolvedEsbmc | undefined> {
   try {
     await executeShellCommand('esbmc --version')
-    return 'esbmc'
+    return { command: 'esbmc', source: 'path' }
   } catch {
     // Not on PATH; fall through to the locations we manage.
   }
-  for (const candidate of [installedBinary(platform), legacyBinary(platform)]) {
+  const candidates: Array<[string | undefined, EsbmcSource]> = [
+    [installedBinary(platform), 'installed'],
+    [legacyBinary(platform), 'legacy']
+  ]
+  for (const [candidate, source] of candidates) {
     if (candidate !== undefined && fs.existsSync(candidate)) {
-      return quoteShellArg(candidate)
+      return { command: quoteShellArg(candidate), source }
     }
   }
   return undefined
+}
+
+/** @returns undefined when ESBMC cannot be found anywhere. */
+export async function resolveEsbmcCommand (platform: string = process.platform): Promise<string | undefined> {
+  return (await resolveEsbmc(platform))?.command
 }

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,48 @@
+import * as path from 'path'
+import { quoteShellArg } from './commands'
+
+const ASSETS: Record<string, string> = {
+  linux: 'esbmc-linux.zip',
+  darwin: 'esbmc-macos.zip',
+  win32: 'esbmc-windows.zip'
+}
+
+export function isSupportedPlatform (platform: string): boolean {
+  return platform in ASSETS
+}
+
+/** The release asset ESBMC publishes for a platform. */
+export function assetForPlatform (platform: string): string {
+  const asset = ASSETS[platform]
+  if (asset === undefined) {
+    throw Error(`ESBMC publishes no build for ${platform}`)
+  }
+  return asset
+}
+
+export function binaryName (platform: string): string {
+  return platform === 'win32' ? 'esbmc.exe' : 'esbmc'
+}
+
+/**
+ * Where the binary ends up inside the install directory.
+ *
+ * The archives keep it in `bin/`, alongside `libz3.dll` on Windows, so the
+ * whole directory is kept rather than the binary lifted out of it.
+ */
+export function binaryPath (installDir: string, platform: string): string {
+  return path.join(installDir, 'bin', binaryName(platform))
+}
+
+/**
+ * A command that unpacks a zip, since Windows has no `unzip`. PowerShell
+ * single-quoted strings escape a quote by doubling it.
+ */
+export function extractCommand (zip: string, destination: string, platform: string): string {
+  if (platform === 'win32') {
+    const literal = (value: string) => `'${value.replace(/'/g, "''")}'`
+    return 'powershell -NoProfile -NonInteractive -Command ' +
+      `"Expand-Archive -Force -LiteralPath ${literal(zip)} -DestinationPath ${literal(destination)}"`
+  }
+  return `unzip -o ${quoteShellArg(zip)} -d ${quoteShellArg(destination)}`
+}

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,5 +1,4 @@
 import * as path from 'path'
-import { quoteShellArg } from './commands'
 
 const ASSETS: Record<string, string> = {
   linux: 'esbmc-linux.zip',
@@ -34,15 +33,31 @@ export function binaryPath (installDir: string, platform: string): string {
   return path.join(installDir, 'bin', binaryName(platform))
 }
 
+export interface Command {
+  file: string
+  args: string[]
+}
+
 /**
- * A command that unpacks a zip, since Windows has no `unzip`. PowerShell
- * single-quoted strings escape a quote by doubling it.
+ * Unpacks a zip, since Windows has no `unzip`.
+ *
+ * Returned as a program and its arguments rather than a command line: run
+ * through a shell, `cmd.exe` would substitute `%VAR%` in a storage path
+ * before PowerShell ever saw it. PowerShell single-quoted strings still
+ * escape a quote by doubling it, since -Command takes one script.
  */
-export function extractCommand (zip: string, destination: string, platform: string): string {
+export function extractCommand (zip: string, destination: string, platform: string): Command {
   if (platform === 'win32') {
     const literal = (value: string) => `'${value.replace(/'/g, "''")}'`
-    return 'powershell -NoProfile -NonInteractive -Command ' +
-      `"Expand-Archive -Force -LiteralPath ${literal(zip)} -DestinationPath ${literal(destination)}"`
+    return {
+      file: 'powershell',
+      args: [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `Expand-Archive -Force -LiteralPath ${literal(zip)} -DestinationPath ${literal(destination)}`
+      ]
+    }
   }
-  return `unzip -o ${quoteShellArg(zip, platform)} -d ${quoteShellArg(destination, platform)}`
+  return { file: 'unzip', args: ['-o', zip, '-d', destination] }
 }

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -44,5 +44,5 @@ export function extractCommand (zip: string, destination: string, platform: stri
     return 'powershell -NoProfile -NonInteractive -Command ' +
       `"Expand-Archive -Force -LiteralPath ${literal(zip)} -DestinationPath ${literal(destination)}"`
   }
-  return `unzip -o ${quoteShellArg(zip)} -d ${quoteShellArg(destination)}`
+  return `unzip -o ${quoteShellArg(zip, platform)} -d ${quoteShellArg(destination, platform)}`
 }

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -1,5 +1,6 @@
 import { Request, default as fetch } from 'node-fetch'
-import { executeShellCommand } from './commands'
+import { runShellCommand } from './commands'
+import { resolveEsbmcCommand } from './esbmcPath'
 
 export async function getLatestVersion () {
   const request = new Request('https://github.com/esbmc/esbmc/releases/latest')
@@ -9,19 +10,15 @@ export async function getLatestVersion () {
 }
 
 export async function getInstalledVersion (): Promise<string | undefined> {
-  let out
-  try {
-    out = await executeShellCommand('$HOME/bin/esbmc --version 2>&1')
-  } catch (error) { }
-  if (!out) {
-    try {
-      out = await executeShellCommand('esbmc --version 2>&1')
-    } catch (error) {
-      return undefined
-    }
+  const esbmc = await resolveEsbmcCommand()
+  if (esbmc === undefined) {
+    return undefined
   }
+  // ESBMC prints its banner on stderr, and exits non-zero on some platforms
+  // when given only --version, so both streams are kept.
+  const result = await runShellCommand(`${esbmc} --version`)
   const regex = /ESBMC version (\d+\.)?(\d+\.)?(\*|\d+)/g
-  const match = out.match(regex)?.[0]
+  const match = (result.stdout + result.stderr).match(regex)?.[0]
   if (!match) {
     return undefined
   }

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -9,11 +9,14 @@ export async function getLatestVersion () {
   return redirUrl.split('/').pop()?.replace('v', '')
 }
 
-export async function getInstalledVersion (): Promise<string | undefined> {
-  const esbmc = await resolveEsbmcCommand()
-  if (esbmc === undefined) {
-    return undefined
-  }
+/**
+ * Asks one particular ESBMC for its version.
+ *
+ * @param esbmc the command, already quoted for a shell. Naming the binary
+ * matters right after an install: the resolver would answer with whatever is
+ * on PATH rather than what was just unpacked.
+ */
+export async function readVersion (esbmc: string): Promise<string | undefined> {
   // ESBMC prints its banner on stderr, and exits non-zero on some platforms
   // when given only --version, so both streams are kept.
   const result = await runShellCommand(`${esbmc} --version`)
@@ -23,4 +26,9 @@ export async function getInstalledVersion (): Promise<string | undefined> {
     return undefined
   }
   return match.replace('ESBMC version ', '')
+}
+
+export async function getInstalledVersion (): Promise<string | undefined> {
+  const esbmc = await resolveEsbmcCommand()
+  return esbmc === undefined ? undefined : readVersion(esbmc)
 }


### PR DESCRIPTION
The installer hard-coded the Linux archive and shelled out to `unzip`, `mkdir -p` and `chmod`, none of which work on Windows. It now picks the asset for the running platform, unpacks with PowerShell where there is no `unzip`, and keeps the archive's `bin/` directory intact — I checked all three archives, and Windows ships `libz3.dll` next to `esbmc.exe`, so lifting the binary out the way the Linux path did would break it.

Installs go to the extension's own storage instead of `$HOME/bin`, so nothing needs a `PATH` change. One resolver now decides which ESBMC runs, because `versions.ts` preferred `$HOME/bin` while `run.ts` preferred `PATH` — the reported version and the verified binary could disagree. A user's own ESBMC on `PATH` wins; the test that pinned the old precedence is updated deliberately.

`extensionKind: ["workspace"]` is set so Remote-SSH, WSL and Dev Containers run ESBMC where the code is, and the README documents that route.

Asset names were verified against the releases API, and the archive layouts by downloading and listing them. The pure parts (platform mapping, extraction commands, resolver) are covered by tests and mutation-checked; the download orchestration itself needs the VS Code API and is not.

Stacked on #27 — merge order is #24 → #23 → #25 → #26 → #27 → this.

Fixes #16