### PR TITLE
Automate publishing to the Marketplace and Open VSX

### DIFF
--- a/.github/workflows/on-pr-master.yml
+++ b/.github/workflows/on-pr-master.yml
@@ -5,26 +5,14 @@ on:
     branches:
       - master
 
+env:
+  # Pinned: an unpinned npx resolves the newest release at run time, so a
+  # breaking one would break packaging with no change here.
+  VSCE: '@vscode/vsce@3.9.2'
+
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Install Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 22.x
-        cache: npm
-    - run: npm ci
-    - run: xvfb-run -a npm test
-      if: runner.os == 'Linux'
-    - run: npm test
-      if: runner.os != 'Linux'
+    uses: ./.github/workflows/test.yml
 
   package:
     runs-on: ubuntu-latest
@@ -39,9 +27,11 @@ jobs:
     - run: npm ci
     # Catches a broken manifest or a .vscodeignore that drops shipped assets
     # before a release tag does.
-    - run: npx --yes @vscode/vsce package --out vscode-esbmc.vsix
+    - run: npx --yes "$VSCE" package --out vscode-esbmc.vsix
     - name: Check the walkthrough assets are packaged
+      # Read out of the archive rather than asking vsce to list what it would
+      # package: only the archive is what ships.
       run: |
-        npx --yes @vscode/vsce ls > packaged.txt
-        grep -q "examples/buffer-overflow.c" packaged.txt
-        grep -q "walkthroughs/install.md" packaged.txt
+        unzip -Z1 vscode-esbmc.vsix > packaged.txt
+        grep -qx "extension/examples/buffer-overflow.c" packaged.txt
+        grep -qx "extension/walkthroughs/install.md" packaged.txt

--- a/.github/workflows/on-pr-master.yml
+++ b/.github/workflows/on-pr-master.yml
@@ -25,3 +25,23 @@ jobs:
       if: runner.os == 'Linux'
     - run: npm test
       if: runner.os != 'Linux'
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+        cache: npm
+    - run: npm ci
+    # Catches a broken manifest or a .vscodeignore that drops shipped assets
+    # before a release tag does.
+    - run: npx --yes @vscode/vsce package --out vscode-esbmc.vsix
+    - name: Check the walkthrough assets are packaged
+      run: |
+        npx --yes @vscode/vsce ls > packaged.txt
+        grep -q "examples/buffer-overflow.c" packaged.txt
+        grep -q "walkthroughs/install.md" packaged.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,26 +5,15 @@ on:
     tags:
       - 'v*'
 
+env:
+  # Pinned: an unpinned npx resolves the newest release at run time, so a
+  # breaking one would break releases with no change here.
+  VSCE: '@vscode/vsce@3.9.2'
+  OVSX: 'ovsx@1.1.1'
+
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Install Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 22.x
-        cache: npm
-    - run: npm ci
-    - run: xvfb-run -a npm test
-      if: runner.os == 'Linux'
-    - run: npm test
-      if: runner.os != 'Linux'
+    uses: ./.github/workflows/test.yml
 
   publish:
     needs: test
@@ -47,13 +36,13 @@ jobs:
           exit 1
         fi
     - name: Package
-      run: npx --yes @vscode/vsce package --out vscode-esbmc.vsix
+      run: npx --yes "$VSCE" package --out vscode-esbmc.vsix
     - name: Publish to the VS Code Marketplace
-      run: npx --yes @vscode/vsce publish --packagePath vscode-esbmc.vsix
+      run: npx --yes "$VSCE" publish --packagePath vscode-esbmc.vsix
       env:
         VSCE_PAT: ${{ secrets.VSCE_PAT }}
     - name: Publish to Open VSX
-      run: npx --yes ovsx publish vscode-esbmc.vsix
+      run: npx --yes "$OVSX" publish vscode-esbmc.vsix
       env:
         OVSX_PAT: ${{ secrets.OVSX_PAT }}
     - name: Attach the VSIX to the release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+        cache: npm
+    - run: npm ci
+    - run: xvfb-run -a npm test
+      if: runner.os == 'Linux'
+    - run: npm test
+      if: runner.os != 'Linux'
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+        cache: npm
+    - run: npm ci
+    - name: Check the tag matches package.json
+      run: |
+        tag="${GITHUB_REF_NAME#v}"
+        version="$(node -p "require('./package.json').version")"
+        if [ "$tag" != "$version" ]; then
+          echo "tag $GITHUB_REF_NAME does not match package.json version $version" >&2
+          exit 1
+        fi
+    - name: Package
+      run: npx --yes @vscode/vsce package --out vscode-esbmc.vsix
+    - name: Publish to the VS Code Marketplace
+      run: npx --yes @vscode/vsce publish --packagePath vscode-esbmc.vsix
+      env:
+        VSCE_PAT: ${{ secrets.VSCE_PAT }}
+    - name: Publish to Open VSX
+      run: npx --yes ovsx publish vscode-esbmc.vsix
+      env:
+        OVSX_PAT: ${{ secrets.OVSX_PAT }}
+    - name: Attach the VSIX to the release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: vscode-esbmc.vsix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+# Called by both the pull-request run and the release run, so the two cannot
+# drift into testing different things.
+on:
+  workflow_call:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+        cache: npm
+    - run: npm ci
+    - run: xvfb-run -a npm test
+      if: runner.os == 'Linux'
+    - run: npm test
+      if: runner.os != 'Linux'

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,18 @@
+# Sources and build tooling; the compiled extension in out/ is what ships.
+src/**
+out/test/**
+out/**/*.map
+tsconfig.json
+.eslintrc.json
+vsc-extension-quickstart.md
+
+# Repository plumbing.
+.claude/**
+.github/**
+.vscode/**
+.vscode-test/**
+.gitignore
+**/*.vsix
+
+# examples/ and walkthroughs/ are deliberately NOT ignored: the Welcome
+# walkthrough reads them from the installed extension directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- A tag-triggered workflow that runs the test matrix, packages the extension
+  and publishes it to the VS Code Marketplace and Open VSX, then attaches the
+  VSIX to the release. Needs `VSCE_PAT` and `OVSX_PAT` repository secrets.
+- Pull requests now package the extension as well as testing it, and check
+  that the walkthrough assets are still included.
+
+### Changed
+
+- Marketplace metadata: `repository`, `bugs`, `homepage`, `keywords`, and
+  categories widened from `Other` to Testing, Linters and Programming
+  Languages. The publisher is now `esbmc` rather than a personal account.
+- A `.vscodeignore` keeps sources, tests and repository plumbing out of the
+  VSIX, which drops it from 492 to 406 files.
+
 ## [0.1.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -229,6 +229,20 @@ VS Code opens a terminal showing:
 - verification progress,
 - and the final result.
 
+## 11.2 Releasing
+
+Publishing is automated. Tag a commit whose `package.json` version matches the
+tag and push it:
+
+```bash
+git tag v0.1.0 && git push origin v0.1.0
+```
+
+The `Publish` workflow runs the tests on all three platforms, packages the
+extension, publishes it to the VS Code Marketplace and Open VSX, and attaches
+the VSIX to the GitHub release. It needs two repository secrets, `VSCE_PAT`
+and `OVSX_PAT`, and a registered `esbmc` publisher on both registries.
+
 ## 12. Summary
 
 By following the steps in this README, you can:

--- a/package.json
+++ b/package.json
@@ -2,12 +2,15 @@
   "name": "vscode-esbmc",
   "displayName": "ESBMC",
   "description": "Verify C and C++ programs from VS Code with ESBMC, the Efficient SMT-based Bounded Model Checker",
-  "publisher": "jossmoff",
+  "publisher": "esbmc",
   "version": "0.1.0",
   "engines": {
     "vscode": "^1.68.0"
   },
   "categories": [
+    "Testing",
+    "Linters",
+    "Programming Languages",
     "Other"
   ],
   "activationEvents": [
@@ -823,5 +826,23 @@
     "mocha": {
       "serialize-javascript": "^7.1.0"
     }
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/esbmc/vscode-esbmc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/esbmc/vscode-esbmc/issues"
+  },
+  "homepage": "http://esbmc.org/",
+  "keywords": [
+    "esbmc",
+    "bounded model checking",
+    "formal verification",
+    "static analysis",
+    "c",
+    "c++",
+    "solidity",
+    "python"
+  ]
 }


### PR DESCRIPTION
A tag-triggered workflow runs the test matrix, packages the extension, publishes to the VS Code Marketplace and Open VSX, and attaches the VSIX to the release. It refuses to publish if the tag and `package.json` version disagree. Pull requests now package the extension as well, and assert the walkthrough assets are still in the VSIX, so a broken manifest or over-eager `.vscodeignore` surfaces on the PR rather than at release time.

I ran `vsce package` locally against each change. Of its four warnings, three are gone: `repository` is set, a `.vscodeignore` exists, and the file count drops from 492 to 406 (sources, tests and repo plumbing no longer ship). `examples/` and `walkthroughs/` are deliberately kept — the Welcome walkthrough reads them from the installed extension directory — and that is what the new CI check pins.

**Three things need you, not me:**

- **LICENSE.** The remaining `vsce` warning. This repo declares no license and `esbmc/esbmc` is `NOASSERTION`, so I am not going to pick one.
- **Publisher `esbmc`.** `package.json` now says `esbmc` instead of `jossmoff`, as the issue asks — but publishing fails until that publisher ID is registered on both the Marketplace and Open VSX.
- **Secrets `VSCE_PAT` and `OVSX_PAT`.**

The issue also asks for an icon and a README screenshot/GIF. Both need design or a running instance, so neither is here.

Fixes #15
Fixes #4