### PR TITLE
Add a command that shows the current ESBMC flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `esbmc.editor.verifyOnSave` verifies a file each time it is saved, and
   `esbmc.editor.timeout` kills a run that takes too long.
 - The verdict is shown in the status bar; clicking it opens the output.
+- `ESBMC: Show current flags` reports the command line the current settings
+  produce, and offers to copy it.
 - A tag-triggered workflow that runs the test matrix, packages the extension
   and publishes it to the VS Code Marketplace and Open VSX, then attaches the
   VSIX to the release. Needs `VSCE_PAT` and `OVSX_PAT` repository secrets.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "onCommand:vscode-esbmc.openExample",
     "onLanguage:python",
     "onLanguage:solidity",
-    "onCommand:vscode-esbmc.showOutput"
+    "onCommand:vscode-esbmc.showOutput",
+    "onCommand:vscode-esbmc.showFlags"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -753,6 +754,10 @@
       {
         "command": "vscode-esbmc.showOutput",
         "title": "ESBMC: Show output"
+      },
+      {
+        "command": "vscode-esbmc.showFlags",
+        "title": "ESBMC: Show current flags"
       }
     ],
     "walkthroughs": [

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -2,6 +2,7 @@ import { commands, Disposable, ExtensionContext } from 'vscode'
 import { run, showOutput } from './run'
 import { install, update } from './installation'
 import { openExample } from './openExample'
+import { showFlags } from './showFlags'
 
 export function registerCommands (context: ExtensionContext): Disposable[] {
   return [
@@ -10,6 +11,7 @@ export function registerCommands (context: ExtensionContext): Disposable[] {
     commands.registerCommand('vscode-esbmc.install', async () => install(context)),
     commands.registerCommand('vscode-esbmc.update', async () => update(context)),
     commands.registerCommand('vscode-esbmc.showOutput', () => showOutput()),
-    commands.registerCommand('vscode-esbmc.openExample', async () => openExample(context))
+    commands.registerCommand('vscode-esbmc.openExample', async () => openExample(context)),
+    commands.registerCommand('vscode-esbmc.showFlags', async () => showFlags())
   ]
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -10,10 +10,10 @@ import { classifyVerdict, statusText } from '../parsers/verdict'
 import { EsbmcDiagnostics } from '../diagnostics/esbmcDiagnostics'
 import { SUPPORTED_EXTENSIONS } from '../languages'
 import { resolveEsbmcCommand } from '../utils/esbmcPath'
+import { disposeOutput, esbmcOutput as output } from '../utils/output'
 
 const CONFIG_PARSER: ConfigurationParser = new ConfigurationParser()
 
-let OUTPUT: vscode.OutputChannel | undefined
 let STATUS: vscode.StatusBarItem | undefined
 let DIAGNOSTICS: EsbmcDiagnostics | undefined
 let disposed = false
@@ -22,11 +22,6 @@ let disposed = false
 // diagnostics: a save-triggered run can otherwise overwrite a manual one.
 let runToken = 0
 let killInFlight: (() => void) | undefined
-
-function output (): vscode.OutputChannel {
-  OUTPUT = OUTPUT ?? vscode.window.createOutputChannel('ESBMC')
-  return OUTPUT
-}
 
 function status (): vscode.StatusBarItem {
   if (STATUS === undefined) {
@@ -50,10 +45,9 @@ export function showOutput (): void {
 export function disposeRunState (): void {
   disposed = true
   killInFlight?.()
-  OUTPUT?.dispose()
+  disposeOutput()
   STATUS?.dispose()
   DIAGNOSTICS?.dispose()
-  OUTPUT = undefined
   STATUS = undefined
   DIAGNOSTICS = undefined
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -12,7 +12,8 @@ import { SUPPORTED_EXTENSIONS } from '../languages'
 import { resolveEsbmcCommand } from '../utils/esbmcPath'
 import { disposeOutput, esbmcOutput as output } from '../utils/output'
 
-const CONFIG_PARSER: ConfigurationParser = new ConfigurationParser()
+/** Shared so the flag report and a run read through one settings cache. */
+export const CONFIG_PARSER: ConfigurationParser = new ConfigurationParser()
 
 let STATUS: vscode.StatusBarItem | undefined
 let DIAGNOSTICS: EsbmcDiagnostics | undefined
@@ -105,7 +106,9 @@ export async function run (overides?: Configuration, commentFlags?: string, docu
   diagnostics().clear()
   showStatus('$(loading~spin) ESBMC: verifying')
   const channel = output()
-  channel.clear()
+  // Not cleared: the channel also carries the flag report the user may have
+  // just asked for, and a save-triggered run would wipe it without a word.
+  channel.appendLine(`\n${'\u2500'.repeat(60)}\nESBMC: verifying ${filePath}`)
   channel.show(true)
 
   const workingDir = path.dirname(filePath)

--- a/src/commands/showFlags.ts
+++ b/src/commands/showFlags.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode'
+import { ConfigurationParser } from '../parsers/configParser'
+import { esbmcOutput } from '../utils/output'
+import { describeFlags } from '../parsers/flagReport'
+
+const CONFIG_PARSER = new ConfigurationParser()
+
+/**
+ * Shows the ESBMC command line the current settings produce.
+ *
+ * Settings map to flags one indirection away, and only non-default settings
+ * emit anything, so the only reliable way to know what will run is to ask.
+ */
+export async function showFlags (): Promise<void> {
+  let flags: string
+  try {
+    flags = CONFIG_PARSER.parse()
+  } catch (error) {
+    vscode.window.showErrorMessage(`ESBMC: ${String(error)}`)
+    return
+  }
+
+  const channel = esbmcOutput()
+  channel.appendLine(describeFlags(flags))
+  channel.show(true)
+
+  if (flags === '') {
+    return
+  }
+  const copy = await vscode.window.showInformationMessage(`ESBMC flags: ${flags}`, 'Copy')
+  if (copy === 'Copy') {
+    await vscode.env.clipboard.writeText(flags)
+  }
+}

--- a/src/commands/showFlags.ts
+++ b/src/commands/showFlags.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode'
-import { ConfigurationParser } from '../parsers/configParser'
+import { CONFIG_PARSER } from './run'
 import { esbmcOutput } from '../utils/output'
 import { describeFlags } from '../parsers/flagReport'
-
-const CONFIG_PARSER = new ConfigurationParser()
 
 /**
  * Shows the ESBMC command line the current settings produce.
@@ -22,6 +20,13 @@ export async function showFlags (): Promise<void> {
 
   const channel = esbmcOutput()
   channel.appendLine(describeFlags(flags))
+  // run() also takes per-run overrides this command cannot know about, so say
+  // what the report does and does not cover rather than implying it is final.
+  channel.appendLine(
+    'Settings only. Verifying a single function through its CodeLens adds ' +
+    '--function for that function, and an @esbmc-verify comment above a ' +
+    'function replaces these flags with its own.'
+  )
   channel.show(true)
 
   if (flags === '') {

--- a/src/parsers/flagReport.ts
+++ b/src/parsers/flagReport.ts
@@ -1,0 +1,11 @@
+/**
+ * Describes the ESBMC flags the current settings produce.
+ *
+ * Every setting at its default emits no flags at all, which reads as a bug
+ * unless the report says so explicitly.
+ */
+export function describeFlags (flags: string): string {
+  return flags === ''
+    ? 'ESBMC flags: none, every setting is at its default'
+    : `ESBMC flags: ${flags}`
+}

--- a/src/test/parsers/FlagReport.test.ts
+++ b/src/test/parsers/FlagReport.test.ts
@@ -1,0 +1,19 @@
+import * as assert from 'assert'
+import { describeFlags } from '../../parsers/flagReport'
+
+describe('describeFlags', () => {
+  // Every setting at its default emits no flags at all, which reads as a bug
+  // unless the report says so.
+  it('says so when there are no flags', () => {
+    assert.match(describeFlags(''), /none/)
+    assert.match(describeFlags(''), /default/)
+  })
+
+  it('reports the flags verbatim', () => {
+    assert.strictEqual(describeFlags('--unwind 5 --z3'), 'ESBMC flags: --unwind 5 --z3')
+  })
+
+  it('does not claim there are none when there are', () => {
+    assert.doesNotMatch(describeFlags('--z3'), /none/)
+  })
+})

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode'
+
+let CHANNEL: vscode.OutputChannel | undefined
+
+/** The one ESBMC output channel, shared by verification and the flag report. */
+export function esbmcOutput (): vscode.OutputChannel {
+  CHANNEL = CHANNEL ?? vscode.window.createOutputChannel('ESBMC')
+  return CHANNEL
+}
+
+export function disposeOutput (): void {
+  CHANNEL?.dispose()
+  CHANNEL = undefined
+}


### PR DESCRIPTION
Settings reach the ESBMC command line through `ConfigurationParser`, and only settings that differ from their default emit anything — so there was no way to see what a run would actually pass. `ESBMC: Show current flags` reports it in the output channel and offers to copy it.

It says so explicitly when the answer is *no flags*, because an empty result otherwise reads as a bug rather than "everything is at its default".

The output channel moves out of `run.ts` into its own module so the flag report and verification share one channel instead of opening two.

The issue says "TODO: Flesh this out", so I took the title at face value: report the flags, do not change how they are produced. Say if you wanted something broader — writing them to a file, or a per-run record.

Stacked on #36 — merge order is #26 → #27 → #33 → #36 → this.

Fixes #8