### PR TITLE
Rewrite the README for people who install the extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Changed
 
+- The README is now a description of what the extension does rather than a
+  build-from-source walkthrough, with the build, test and release instructions
+  moved to `CONTRIBUTING.md`. It no longer walks the reader through a test log
+  that was never in the repository.
+
 - The installer downloads the asset for the running platform and unpacks it
   into the extension's storage directory instead of hard-coding the Linux
   archive and writing to `$HOME/bin`. Windows uses PowerShell to unpack, since

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing
+
+Issues and pull requests are welcome at
+[github.com/esbmc/vscode-esbmc](https://github.com/esbmc/vscode-esbmc).
+
+## Building from source
+
+You need Node.js 22 (the version CI uses) and npm.
+
+```bash
+git clone https://github.com/esbmc/vscode-esbmc.git
+cd vscode-esbmc
+npm ci
+npm run compile
+```
+
+Press <kbd>F5</kbd> in VS Code to launch an Extension Development Host with the
+extension loaded.
+
+## Tests
+
+```bash
+npm test
+```
+
+This downloads a VS Code build and runs the suite inside it, so it needs a
+display; on a headless Linux machine use `xvfb-run -a npm test`.
+
+The manifest checks need neither VS Code nor a display, so they can be run on
+their own while iterating:
+
+```bash
+npm run compile && npm run test:package
+```
+
+Much of the rest of the suite also avoids importing `vscode` — deliberately,
+so it stays runnable outside the harness — and can be pointed at directly with
+`node node_modules/mocha/bin/mocha.js --ui bdd out/test/utils/*.test.js`.
+Tests that shell out to ESBMC skip themselves when it is not installed, so a
+machine without it still gets a green run, just a smaller one.
+
+`npm run pretest` compiles and lints, and is what CI gates on.
+
+## Packaging
+
+```bash
+npx @vscode/vsce package
+```
+
+`.vscodeignore` keeps sources and tests out of the VSIX. `examples/` and
+`walkthroughs/` must stay in it — the Welcome walkthrough reads them from the
+installed extension directory, and a CI check asserts they are still there.
+
+## Releasing
+
+Publishing is automated. Tag a commit whose `package.json` version matches the
+tag and push it:
+
+```bash
+git tag v0.1.0 && git push origin v0.1.0
+```
+
+The `Publish` workflow runs the tests on macOS, Linux and Windows, packages the
+extension, publishes it to the VS Code Marketplace and Open VSX, and attaches
+the VSIX to the GitHub release. It refuses to publish if the tag and the
+`package.json` version disagree.
+
+It needs two repository secrets, `VSCE_PAT` and `OVSX_PAT`, and a registered
+`esbmc` publisher on both registries.
+
+## Conventions
+
+- ESLint enforces [standard](https://standardjs.com/) style; `npm run lint`
+  must pass, and it covers the tests as well as `src/`.
+- Settings that map to ESBMC flags live in `package.json` under
+  `contributes.configuration`, and `src/parsers/configParser.ts` turns them
+  into a command line. A manifest test requires every enum value to carry a
+  `markdownEnumDescriptions` entry.
+- Keep anything that does not need the VS Code API free of `vscode` imports.
+  That boundary is what lets most of the suite run without the Electron
+  harness, and it is easy to lose by accident.

--- a/README.md
+++ b/README.md
@@ -1,364 +1,128 @@
 # ESBMC for Visual Studio Code
 
-This README explains how to go from the extension source code to a working ESBMC integration inside Visual Studio Code on **Linux**, incorporating the lessons learned from the test log in `Teste_ESBMC.txt`.
-
----
-
-## 1. Overview
-
-The ESBMC VS Code extension allows you to:
-
-- Run ESBMC on the **current C, C++, Python or Solidity file** directly from the editor.
-- Install (download + unpack) the **latest ESBMC** binary on Linux, macOS or Windows using a dedicated command.
-- See violated properties as squiggles in the editor and in the Problems panel, with the raw ESBMC output in an `ESBMC` output channel.
-
-Once the extension is installed, **Help → Welcome → Get started with ESBMC**
-walks through installing ESBMC, opening the bundled `examples/buffer-overflow.c`
-and reading the counterexample it produces.
-
-This document assumes you are using a Debian/Ubuntu-based distribution and the **bash** shell.
-
----
-
-## 2. Requirements
-
-Before building and using the extension, make sure you have:
-
-- **Linux**, **macOS** or **Windows**. The build instructions below were written on Ubuntu; the packaged extension runs on all three.
-- **Visual Studio Code** installed.
-- **curl** and **git** (for downloads and version control).
-- **unzip** installed on your system (required for automatic ESBMC installation).
-- **Node.js (LTS)** and **npm**, installed via **nvm (Node Version Manager)**.
-- **vsce** (VS Code Extension Manager) to package the extension as a `.vsix`.
-
----
-
-## 3. Step 1 – Prepare the development environment
-
-### 3.1 Install essential tools
-
-Open a terminal and run:
-
-```bash
-sudo apt update
-sudo apt install curl git unzip -y
-```
-
-### 3.2 Install Node.js LTS using nvm
-#### 3.2.1. **Install `nvm`:**
-
-   ```bash
-   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-   ```
-
-#### 3.2.2. **Load `nvm` into the current shell:**
-  
-   ```bash
-   source ~/.bashrc
-   ```
-
-#### 3.2.3. **Install Node.js LTS:**
-
-   ```bash
-   nvm install --lts
-   ```
-
-#### 3.2.4. **Verify `node` and `npm`:**
-
-   ```bash
-   node -v
-   npm -v
-   ```
-
-You should see version numbers for Node.js and npm without errors.
-
----
-
-## 4. Step 2 – Obtain the extension source code
-
-Download or clone the ESBMC VS Code extension repository and move into the project folder. For example:
-
-```bash
-git clone https://github.com/esbmc/vscode-esbmc.git
-cd vscode-esbmc
-```
-
-The exact directory name may vary; just ensure you are in the folder that contains `package.json`.
-
----
-
-## 5. Step 3 – Install project dependencies
-
-Install the required npm packages with:
-
-```bash
-npm install
-```
-
-Notes based on the test:
-
-- This step **worked correctly**.
-- `npm audit` should report no vulnerabilities. If it reports some, check
-  whether the affected package is a runtime `dependency` before assuming it is
-  harmless — only the build and test toolchain is exempt.
-
-  ```bash
-  npm audit
-  ```
-
-  Note that `npm audit fix` is not always the answer: `serialize-javascript` is
-  pinned through `overrides` because `npm audit fix` proposes an unhelpful mocha
-  downgrade instead. Dependabot opens weekly update pull requests, so the
-  lockfile should not drift far behind.
-
----
-
-## 6. Step 4 – Compile the TypeScript code
-
-Compile the extension (TypeScript → JavaScript) with:
-
-```bash
-npm run compile
-```
-
-### 6.1 Handling “Permission denied” for `tsc`
-
-If you see a `Permission denied` error when running `npm run compile`, fix the permissions for the TypeScript compiler and re-run the command:
-
-```bash
-chmod +x ./node_modules/.bin/tsc
-npm run compile
-```
-
-After a successful compilation, a directory named `out` will be created in the project folder.
-
----
-
-## 7. Step 5 – Package the extension as a `.vsix`
-
-### 7.1 Install `vsce` globally
-
-Use npm to install `vsce`:
-
-```bash
-npm install -g @vscode/vsce
-```
-
-### 7.2 Create the `.vsix` package
-
-From the root of the project (where `package.json` is located), run:
-
-```bash
-vsce package
-```
-
-Typical behavior:
-
-- `vsce` may ask or warn about:
-  - `README.md` contents,
-  - missing `LICENSE`,
-  - missing `repository` field.
-- You can confirm the prompts with `y` to continue.
-
-At the end, you should see a file such as:
-
-```text
-vscode-esbmc-0.1.0.vsix
-```
-
-(or another versioned name) generated in the current directory.
-
----
-
-## 8. Step 6 – Install the `.vsix` in Visual Studio Code
-
-1. Open **Visual Studio Code**.
-2. Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> to open the **Command Palette**.
-3. Run **“Extensions: Install from VSIX…”**.
-4. Navigate to the `.vsix` file you created (e.g. `vscode-esbmc-0.1.0.vsix`) and select it.
-5. After installation, click **“Reload”** to restart VS Code and activate the extension:
-
-````text
-Open the command palette (Ctrl + Shift + P) and execute the command:
-
->Reload Window
-````
-
-After reloading, the ESBMC extension will be available for all your projects.
-
----
-
-## 9. Step 7 – Install ESBMC via the extension
-
-With the extension installed and active:
-
-1. Open the **Command Palette** (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>).
-2. Look for and run:
-
-   ```text
-   ESBMC: Install the latest version
-   ```
-
-   If ESBMC is already installed, you could also do the following:
-
-   ````text
-   ESBMC: Update to latest version
-   ````
-
-The extension downloads the release asset for your platform (`esbmc-linux.zip`, `esbmc-macos.zip` or `esbmc-windows.zip`) and unpacks it into its own storage directory, so nothing is written to `$HOME/bin` and no `PATH` change is needed.
-
----
-
-## 10. Step 8 – Using the extension
-
-### 10.1 Verify a file
-
-According to `Teste_ESBMC.txt`, this workflow was successfully tested:
-
-1. Open a C, C++, Python or Solidity source file in VS Code.
-2. Open the **Command Palette** (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>).
-3. Run:
-
-   ```text
-   ESBMC: Verify file
-   ```
-
-VS Code opens an **ESBMC** output channel showing the command line and the
-full ESBMC output, and reports the verdict in the status bar. Any violated
-property also appears as a squiggle on its line and in the **Problems** panel.
-
-Two settings control this:
+[![Run tests](https://github.com/esbmc/vscode-esbmc/actions/workflows/on-pr-master.yml/badge.svg)](https://github.com/esbmc/vscode-esbmc/actions/workflows/on-pr-master.yml)
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/esbmc.vscode-esbmc)](https://marketplace.visualstudio.com/items?itemName=esbmc.vscode-esbmc)
+[![Open VSX](https://img.shields.io/open-vsx/v/esbmc/vscode-esbmc)](https://open-vsx.org/extension/esbmc/vscode-esbmc)
+
+Find bugs in C, C++, Python and Solidity without leaving the editor, using
+[ESBMC](http://esbmc.org/) — a bounded model checker that proves properties
+rather than sampling inputs. A failure comes with a counterexample; a success
+means no execution violates the property, not merely that none was found.
+
+## Install
+
+1. Install this extension from the
+   [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=esbmc.vscode-esbmc)
+   or [Open VSX](https://open-vsx.org/extension/esbmc/vscode-esbmc).
+2. Run **ESBMC: Install latest version** from the Command Palette
+   (<kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>).
+
+The extension downloads the release build for your platform and unpacks it into
+its own storage directory, so nothing is written to `$HOME/bin` and no `PATH`
+change is needed. An ESBMC already on your `PATH` is used in preference.
+
+New to it? **Help → Welcome → Get started with ESBMC** walks through installing
+ESBMC, opening a bundled example and reading the counterexample it produces.
+
+## How it works
+
+Verification runs ESBMC over the open file, with flags built from your
+settings, and reports the result three ways:
+
+- **Problems panel and squiggles** — each violated property is placed on the
+  line that violates it, read from ESBMC's SARIF report rather than scraped
+  from its log.
+- **Status bar** — the verdict, and how many properties failed. Click it to
+  open the full output.
+- **ESBMC output channel** — the command line that ran, and everything ESBMC
+  printed.
+
+Run **ESBMC: Show current flags** to see the command line your settings produce
+before running anything.
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `ESBMC: Verify file` | Verify the active file |
+| `ESBMC: Show current flags` | Show the flags the current settings produce |
+| `ESBMC: Show output` | Open the ESBMC output channel |
+| `ESBMC: Install latest version` | Download and install ESBMC |
+| `ESBMC: Update to latest version` | Update an existing install |
+| `ESBMC: Open example program` | Open the bundled example |
+| `ESBMC: Verify file with Local AI` | Verify, then explain the counterexample with a local model |
+
+A CodeLens above each function verifies that function on its own.
+
+## Settings
+
+Two settings control the editor integration:
 
 | Setting | Default | Meaning |
 | --- | --- | --- |
 | `esbmc.editor.verifyOnSave` | `false` | Verify a supported file every time it is saved |
 | `esbmc.editor.timeout` | `60` | Kill a run after this many seconds; `0` waits indefinitely |
 
-## 11.1 Running against a remote machine
+Everything else maps to an ESBMC flag, grouped under **Front End**, **BMC**,
+**Solver**, **Property Checking**, **k-Induction**, **Concurrency Checking**
+and **AI Integration** in the Settings UI. Each value documents the flag it
+produces. Only settings that differ from their default emit anything, which is
+why **ESBMC: Show current flags** exists.
 
-The extension is marked `extensionKind: ["workspace"]`, so with **Remote-SSH**,
+## Remote development
+
+The extension declares `extensionKind: ["workspace"]`, so with **Remote-SSH**,
 **WSL** or **Dev Containers** it runs where the code is rather than on the
-local UI host. ESBMC is then installed and executed on the remote machine,
-which is the supported route if you want a Linux ESBMC while working from a
-Windows or macOS desktop.
+local UI host. ESBMC is installed and executed on the remote machine — the
+supported route if you want a Linux ESBMC from a Windows or macOS desktop.
 
-## 11.2 Releasing
+## Local AI explanations (optional)
 
-Publishing is automated. Tag a commit whose `package.json` version matches the
-tag and push it:
+**ESBMC: Verify file with Local AI** runs ESBMC and then asks a local model to
+explain the counterexample and suggest a fix. It is fully offline, through
+[Ollama](https://ollama.ai/), and entirely optional.
 
-```bash
-git tag v0.1.0 && git push origin v0.1.0
-```
+1. Install Ollama and start it:
 
-The `Publish` workflow runs the tests on all three platforms, packages the
-extension, publishes it to the VS Code Marketplace and Open VSX, and attaches
-the VSIX to the GitHub release. It needs two repository secrets, `VSCE_PAT`
-and `OVSX_PAT`, and a registered `esbmc` publisher on both registries.
-
-## 12. Summary
-
-By following the steps in this README, you can:
-
-1. Prepare your Linux environment (curl, git, nvm, Node.js, npm).
-2. Install dependencies and compile the ESBMC VS Code extension (`npm install`, `npm run compile`).
-3. Package the extension as a `.vsix` file with `vsce package`.
-4. Install the `.vsix` into Visual Studio Code.
-5. Use the extension to install ESBMC and verify C, C++, Python and Solidity programs, either at the file level or per function.
-
-## 13. (Optional) Local AI Integration with Ollama
-
-This extension now supports **local AI explanations** for ESBMC verification results.  
-The AI is fully offline, running through the **Ollama** framework on Linux.
-
-This feature is optional — you can continue using ESBMC normally without AI.
-
----
-
-### Requirements for AI usage
-
-- Linux (tested on Ubuntu), macOS and Windows
-- ESBMC installed through this extension
-- Ollama installed and running
-- A local AI model downloaded (recommended below)
-
----
-
-### Install Ollama
-
-Run in terminal:
    ```bash
    curl https://ollama.ai/install.sh | sh
-   ```
-
-Start the service:
-   ```bash
    ollama serve
    ```
-> **Note**  
-> If you see an error such as  
-> `Error: listen tcp 127.0.0.1:11434: bind: address already in use`  
-> it usually means that Ollama is **already running** and listening on port `11434`.
->
-> You can confirm which process is using this port with:
->
-> ```bash
-> sudo lsof -i:11434
-> ```
->
-> And you can check the Ollama service status with:
->
-> ```bash
-> systemctl status ollama
-> ```
->
-> If the service is `active (running)`, you can safely skip `ollama serve` and go directly to the verification step below.
 
+   `Error: listen tcp 127.0.0.1:11434: bind: address already in use` means it
+   is already running; check with `systemctl status ollama`.
 
-Verify that it is running:
+2. Pull the default model:
+
+   ```bash
+   ollama pull llama3.1:8b
+   ```
+
+3. Confirm it answers:
+
    ```bash
    curl http://localhost:11434/api/tags
    ```
 
----
+Host and model are configurable under **AI Integration** (`esbmc.ai.host`,
+`esbmc.ai.model`).
 
-### Install the Recommended Model
+## Troubleshooting
 
-This extension defaults to the model:  `llama3.1:8b`
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `ESBMC: not found` | ESBMC is not installed | Run **ESBMC: Install latest version** |
+| Verification reports no verdict | ESBMC failed before checking anything | Open the ESBMC output channel |
+| `[ERROR] Could not contact local AI` | Ollama is not running | Run `ollama serve` |
+| AI output is very slow | Model too large for the machine | Try a smaller model in `esbmc.ai.model` |
 
-To install it:
-   ```text
-   ollama pull llama3.1:8b
-   ```
+## Contributing
 
----
+Build instructions, the test suite and the release process are in
+[CONTRIBUTING.md](CONTRIBUTING.md). Issues and pull requests are welcome at
+[github.com/esbmc/vscode-esbmc](https://github.com/esbmc/vscode-esbmc).
 
-### How to use AI Verification
+## License
 
-- Open a C, C++, Python or Solidity file in VS Code  
-- Press Ctrl + Shift + P  
-- Run: `ESBMC: Verify File with Local AI`
-
-The output will include:  
-- ESBMC verification results  
-- A concise AI explanation (English only)  
-- Suggested patch with corrected C code
-
----
-
-### Troubleshooting Tips
-
-| Symptom                        | Possible cause            | Fix                             |
-|--------------------------------|--------------------------|--------------------------------|
-| [ERROR] Could not contact local AI | Ollama not running        | Run `ollama serve`              |
-| Very slow output               | Model too large for hardware | Try `llama3.1:3b` model        |
-| ESBMC not detected             | PATH misconfiguration    | Re-install ESBMC via extension  |
-
----
-
-✔ Feature Summary  
-| Feature                          | Status   |
-|---------------------------------|----------|
-| ESBMC Installation              | ✔        |
-| ESBMC Verification inside VS Code |✔      |
-| Local AI-based Analysis using Ollama | NEW ✔ |
+This repository does not yet declare a license. ESBMC itself is distributed
+under its own terms; see [esbmc/esbmc](https://github.com/esbmc/esbmc).

--- a/src/test/package/Documentation.test.ts
+++ b/src/test/package/Documentation.test.ts
@@ -10,6 +10,8 @@ function read (file: string): string {
 
 const manifest = JSON.parse(read('package.json'))
 const readme = read('README.md')
+const contributing = read('CONTRIBUTING.md')
+const scripts = Object.keys(manifest.scripts)
 
 const titles: string[] = manifest.contributes.commands.map((c: any) => c.title)
 const editorSettings = Object.keys(
@@ -52,8 +54,30 @@ describe('README', () => {
 
   // The old README walked through a test log that was never in the repository.
   it('references no file that is not in the repository', () => {
-    for (const [, file] of readme.matchAll(/`([\w-]+\.(?:txt|md))`/g)) {
+    for (const [, file] of readme.matchAll(/`([\w./-]+\.(?:txt|md))`/g)) {
       assert.ok(fs.existsSync(path.join(ROOT, file)), `README references missing file ${file}`)
+    }
+  })
+})
+
+// Same drift the README checks guard against: a renamed script leaves the
+// documented command line silently wrong.
+describe('CONTRIBUTING', () => {
+  it('invokes only scripts package.json defines', () => {
+    for (const doc of [contributing, readme]) {
+      const referenced = [
+        ...doc.matchAll(/\bnpm run ([\w:-]+)/g),
+        ...doc.matchAll(/\bnpm (test)\b/g)
+      ]
+      for (const [, script] of referenced) {
+        assert.ok(scripts.includes(script), `the docs run "${script}", which package.json does not define`)
+      }
+    }
+  })
+
+  it('references no file that is not in the repository', () => {
+    for (const [, file] of contributing.matchAll(/`([\w./-]+\.(?:txt|md))`/g)) {
+      assert.ok(fs.existsSync(path.join(ROOT, file)), `CONTRIBUTING references missing file ${file}`)
     }
   })
 })

--- a/src/test/package/Documentation.test.ts
+++ b/src/test/package/Documentation.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const ROOT = path.resolve(__dirname, '..', '..', '..')
+
+function read (file: string): string {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8').replace(/\r\n/g, '\n')
+}
+
+const manifest = JSON.parse(read('package.json'))
+const readme = read('README.md')
+
+const titles: string[] = manifest.contributes.commands.map((c: any) => c.title)
+const editorSettings = Object.keys(
+  manifest.contributes.configuration.find((g: any) => g.id === 'editor').properties
+)
+
+function commandsTable (): string {
+  const table = /## Commands\n([\s\S]*?)\n## /.exec(readme)
+  assert.ok(table, 'README has no Commands section')
+  return table[1]
+}
+
+describe('README', () => {
+  // The README is the Marketplace listing, so a command it describes that does
+  // not exist is a broken promise to someone who has not installed anything yet.
+  it('documents every contributed command', () => {
+    for (const title of titles) {
+      assert.ok(commandsTable().includes(`\`${title}\``), `the README command table omits "${title}"`)
+    }
+  })
+
+  // Scoped to the commands table: error messages elsewhere in the README are
+  // also prefixed "ESBMC: " without being commands.
+  it('lists no command the extension does not contribute', () => {
+    for (const [, title] of commandsTable().matchAll(/`(ESBMC: [^`]+)`/g)) {
+      assert.ok(titles.includes(title), `README lists "${title}", which is not contributed`)
+    }
+  })
+
+  it('documents the editor settings', () => {
+    for (const setting of editorSettings) {
+      assert.ok(readme.includes(`\`${setting}\``), `README does not document ${setting}`)
+    }
+  })
+
+  it('points at a contributing guide that exists', () => {
+    assert.match(readme, /CONTRIBUTING\.md/)
+    assert.ok(fs.existsSync(path.join(ROOT, 'CONTRIBUTING.md')), 'CONTRIBUTING.md is missing')
+  })
+
+  // The old README walked through a test log that was never in the repository.
+  it('references no file that is not in the repository', () => {
+    for (const [, file] of readme.matchAll(/`([\w-]+\.(?:txt|md))`/g)) {
+      assert.ok(fs.existsSync(path.join(ROOT, file)), `README references missing file ${file}`)
+    }
+  })
+})


### PR DESCRIPTION
The README opened by telling the reader it was "incorporating the lessons learned from the test log in `Teste_ESBMC.txt`" — a file that has never been in this repository — and then spent 364 lines on installing nvm and building a VSIX. It also still described the extension as Linux-only, C/C++ only, with results in a terminal, none of which is true any more.

It is now a description of what the extension does: install, how it reports results, the commands, the settings, remote development, the optional local-AI path, and troubleshooting. The build, test and release instructions move to a new `CONTRIBUTING.md`, which #7 also asks for.

Since #15 makes this the Marketplace listing, a documented command that does not exist is a broken promise to someone who has not installed anything yet — so there is a test holding the command table and the editor settings to the manifest, and refusing any file reference that is not in the repository. I mutation-checked it; two of my first assertions were too loose (a substring match let `esbmc.editor.timeoutt` pass) and are tightened.

**Not done, and needing a human:** the badges include Marketplace and Open VSX ones that stay grey until #15 publishes; the issue also asks for a screenshot or GIF, which needs a running instance; and the license section says plainly that this repository declares none, rather than my picking one.

Stacked on #37 — merge order is #26 → #27 → #33 → #36 → #37 → this.

Fixes #7