### PR TITLE
Drop the two dependencies that cannot be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Changed
 
+- `node-fetch` and `flatten-anything` are gone. Both became ESM-only in their
+  next major and cannot be `require`d from this extension, which compiles to
+  CommonJS, so Dependabot could only ever offer updates that break the build.
+  Two HTTP calls now go through Node's own `http`/`https`, and the settings
+  flattener is fifteen lines pinned by tests recorded from the old dependency.
+
 - The README is now a description of what the extension does rather than a
   build-from-source walkthrough, with the build, test and release instructions
   moved to `CONTRIBUTING.md`. It no longer walks the reader through a test log

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "dependencies": {
         "@microsoft/vscode-file-downloader-api": "^1.0.1",
         "compare-versions": "^4.1.3",
-        "flatten-anything": "^3.0.2",
-        "node-fetch": "^2.6.7",
         "object-hash": "^3.0.0",
         "semver": "^7.3.7"
       },
@@ -19,7 +17,6 @@
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.1",
         "@types/node": "^22.20.1",
-        "@types/node-fetch": "^2.6.2",
         "@types/object-hash": "^2.2.1",
         "@types/semver": "^7.3.10",
         "@types/vscode": "^1.68.0",
@@ -160,16 +157,6 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
       }
     },
     "node_modules/@types/object-hash": {
@@ -534,12 +521,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -752,18 +733,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/compare-versions": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.3.tgz",
@@ -846,15 +815,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/diff": {
@@ -976,22 +936,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1580,23 +1524,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/filter-anything": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/filter-anything/-/filter-anything-2.2.4.tgz",
-      "integrity": "sha512-yWC4q7o9A53SpOtl1/pLriidgkQH9b3BbVxe7T5i/v2BQ1DsnLU6hgTdufEEMH7x6gFlHQ51A1X7H9y9BG7Qmg==",
-      "dependencies": {
-        "is-what": "^3.14.1",
-        "ts-toolbelt": "^9.6.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/filter-anything/node_modules/is-what": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
-      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA=="
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1640,37 +1567,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
       "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true
-    },
-    "node_modules/flatten-anything": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/flatten-anything/-/flatten-anything-3.0.2.tgz",
-      "integrity": "sha512-Tq5WY32z4jHoP3OPXbEaOyA+cqR6Qhx9XnQD98wGCEPMj7NuzEwXTFornGZCuvNOZOlLYv9twbDE97AwWyQpwA==",
-      "dependencies": {
-        "filter-anything": "^2.2.4",
-        "is-what": "^4.1.6"
-      },
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
-      "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2350,17 +2246,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-what": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.7.tgz",
-      "integrity": "sha512-DBVOQNiPKnGMxRMLIYSwERAS5MVY1B7xYiGnpgctsOFvVDz9f9PFXXxMcTOHuoqYp4NK9qFYQaIC1NRRxLMpBQ==",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2524,27 +2409,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -2658,25 +2522,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3478,16 +3323,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/ts-toolbelt": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -3599,20 +3434,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -3857,16 +3678,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
     "@types/object-hash": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-2.2.1.tgz",
@@ -4092,12 +3903,6 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4254,15 +4059,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "compare-versions": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.3.tgz",
@@ -4321,12 +4117,6 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
     },
     "diff": {
       "version": "5.2.2",
@@ -4419,18 +4209,6 @@
       "dev": true,
       "requires": {
         "es-errors": "^1.3.0"
-      }
-    },
-    "es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "requires": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       }
     },
     "es-shim-unscopables": {
@@ -4874,22 +4652,6 @@
         "to-regex-range": "^5.0.1"
       }
     },
-    "filter-anything": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/filter-anything/-/filter-anything-2.2.4.tgz",
-      "integrity": "sha512-yWC4q7o9A53SpOtl1/pLriidgkQH9b3BbVxe7T5i/v2BQ1DsnLU6hgTdufEEMH7x6gFlHQ51A1X7H9y9BG7Qmg==",
-      "requires": {
-        "is-what": "^3.14.1",
-        "ts-toolbelt": "^9.6.0"
-      },
-      "dependencies": {
-        "is-what": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
-          "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA=="
-        }
-      }
-    },
     "find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4921,28 +4683,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
       "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true
-    },
-    "flatten-anything": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/flatten-anything/-/flatten-anything-3.0.2.tgz",
-      "integrity": "sha512-Tq5WY32z4jHoP3OPXbEaOyA+cqR6Qhx9XnQD98wGCEPMj7NuzEwXTFornGZCuvNOZOlLYv9twbDE97AwWyQpwA==",
-      "requires": {
-        "filter-anything": "^2.2.4",
-        "is-what": "^4.1.6"
-      }
-    },
-    "form-data": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
-      "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -5401,11 +5141,6 @@
         "call-bind": "^1.0.2"
       }
     },
-    "is-what": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.7.tgz",
-      "integrity": "sha512-DBVOQNiPKnGMxRMLIYSwERAS5MVY1B7xYiGnpgctsOFvVDz9f9PFXXxMcTOHuoqYp4NK9qFYQaIC1NRRxLMpBQ=="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -5526,21 +5261,6 @@
         "picomatch": "^2.3.1"
       }
     },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.52.0"
-      }
-    },
     "mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -5630,14 +5350,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -6181,16 +5893,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "ts-toolbelt": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
-    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -6277,20 +5979,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -845,7 +845,6 @@
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "^22.20.1",
-    "@types/node-fetch": "^2.6.2",
     "@types/object-hash": "^2.2.1",
     "@types/semver": "^7.3.10",
     "@types/vscode": "^1.68.0",
@@ -864,8 +863,6 @@
   "dependencies": {
     "@microsoft/vscode-file-downloader-api": "^1.0.1",
     "compare-versions": "^4.1.3",
-    "flatten-anything": "^3.0.2",
-    "node-fetch": "^2.6.7",
     "object-hash": "^3.0.0",
     "semver": "^7.3.7"
   },

--- a/src/ai/ollamaClient.ts
+++ b/src/ai/ollamaClient.ts
@@ -1,19 +1,17 @@
 import * as vscode from 'vscode'
-import fetch from 'node-fetch'
+import { postJson } from '../utils/http'
 
 export async function callOllama (prompt: string): Promise<string> {
   const cfg = vscode.workspace.getConfiguration('esbmc.ai')
   const host = cfg.get<string>('host', 'http://localhost:11434')
   const model = cfg.get<string>('model', 'llama3.1:8b')
 
-  const res = await fetch(`${host}/api/generate`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ model, prompt, stream: false })
-  })
+  const res = await postJson(`${host}/api/generate`, { model, prompt, stream: false })
 
-  if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(`HTTP ${res.status}`)
+  }
 
-  const data = await res.json()
+  const data = JSON.parse(res.body)
   return data.response ?? 'No AI response received'
 }

--- a/src/parsers/configParser.ts
+++ b/src/parsers/configParser.ts
@@ -1,6 +1,6 @@
 import { workspace } from 'vscode'
 import { sha1 } from 'object-hash'
-import { flatten } from 'flatten-anything'
+import { flatten } from './flatten'
 
 import { Configuration } from '../@types/vscode.configuration'
 

--- a/src/parsers/flatten.ts
+++ b/src/parsers/flatten.ts
@@ -1,0 +1,24 @@
+function isPlainObject (value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Flattens nested settings into dotted keys, so `properties.assertions` reads
+ * the same way whether the setting is nested in the manifest or not.
+ *
+ * An empty object is kept as a value rather than vanishing, and arrays are
+ * left alone — matching what `flatten-anything` did before it became
+ * ESM-only and could no longer be required from this extension.
+ */
+export function flatten (value: Record<string, unknown>, prefix = ''): Record<string, unknown> {
+  const flat: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    const name = prefix === '' ? key : `${prefix}.${key}`
+    if (isPlainObject(entry) && Object.keys(entry).length > 0) {
+      Object.assign(flat, flatten(entry, name))
+    } else {
+      flat[name] = entry
+    }
+  }
+  return flat
+}

--- a/src/test/parsers/Flatten.test.ts
+++ b/src/test/parsers/Flatten.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert'
+import { flatten } from '../../parsers/flatten'
+
+// Behaviour recorded from flatten-anything@3, the dependency this replaces.
+const CASES: Array<[Record<string, unknown>, Record<string, unknown>]> = [
+  [{ properties: { assertions: false, nan: true } }, { 'properties.assertions': false, 'properties.nan': true }],
+  [{ options: { quiet: true, 'symex-ssa': false } }, { 'options.quiet': true, 'options.symex-ssa': false }],
+  [{ unwind: 5, mainFunction: 'main' }, { unwind: 5, mainFunction: 'main' }],
+  [{ a: { b: { c: 1 } } }, { 'a.b.c': 1 }],
+  [{ empty: {} }, { empty: {} }],
+  [{ arr: [1, 2], nested: { arr: [3] } }, { arr: [1, 2], 'nested.arr': [3] }],
+  [{}, {}],
+  [{ nullish: null }, { nullish: null }]
+]
+
+describe('flatten', () => {
+  it('matches the dependency it replaces', () => {
+    for (const [input, expected] of CASES) {
+      assert.deepStrictEqual(flatten(input), expected, JSON.stringify(input))
+    }
+  })
+
+  it('does not mutate its argument', () => {
+    const input = { properties: { assertions: false } }
+    flatten(input)
+    assert.deepStrictEqual(input, { properties: { assertions: false } })
+  })
+
+  // The settings this flattens are one level deep, but the parser looks keys up
+  // by dotted name, so the separator has to stay a dot.
+  it('joins keys with a dot', () => {
+    assert.deepStrictEqual(Object.keys(flatten({ a: { b: 1 } })), ['a.b'])
+  })
+})

--- a/src/test/utils/Http.test.ts
+++ b/src/test/utils/Http.test.ts
@@ -1,0 +1,89 @@
+import * as assert from 'assert'
+import * as http from 'http'
+import { postJson, request, resolveRedirect } from '../../utils/http'
+
+describe('http', function () {
+  this.timeout(30000)
+
+  let server: http.Server
+  let origin: string
+  let received: Array<{ method?: string, url?: string, body: string, contentType?: string }>
+
+  before(async () => {
+    received = []
+    server = http.createServer((req, res) => {
+      let body = ''
+      req.on('data', chunk => { body += chunk })
+      req.on('end', () => {
+        received.push({
+          method: req.method,
+          url: req.url,
+          body,
+          contentType: req.headers['content-type']
+        })
+        if (req.url === '/hop1') {
+          res.writeHead(302, { Location: '/hop2' })
+          return res.end()
+        }
+        if (req.url === '/hop2') {
+          res.writeHead(301, { Location: `${origin}/final` })
+          return res.end()
+        }
+        if (req.url === '/loop') {
+          res.writeHead(302, { Location: '/loop' })
+          return res.end()
+        }
+        if (req.url === '/boom') {
+          res.writeHead(500)
+          return res.end('no')
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ response: 'ok' }))
+      })
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address() as { port: number }
+    origin = `http://127.0.0.1:${address.port}`
+  })
+
+  after(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()))
+  })
+
+  it('reads a response body and status', async () => {
+    const response = await request(`${origin}/final`)
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(JSON.parse(response.body), { response: 'ok' })
+  })
+
+  it('reports a non-2xx status rather than throwing', async () => {
+    const response = await request(`${origin}/boom`)
+    assert.strictEqual(response.status, 500)
+    assert.strictEqual(response.body, 'no')
+  })
+
+  it('posts JSON with the right content type and length', async () => {
+    await postJson(`${origin}/final`, { model: 'm', prompt: 'p' })
+    const last = received[received.length - 1]
+    assert.strictEqual(last.method, 'POST')
+    assert.strictEqual(last.contentType, 'application/json')
+    assert.deepStrictEqual(JSON.parse(last.body), { model: 'm', prompt: 'p' })
+  })
+
+  // getLatestVersion reads the version out of where /releases/latest lands.
+  it('follows redirects, relative and absolute, to where they land', async () => {
+    assert.strictEqual(await resolveRedirect(`${origin}/hop1`), `${origin}/final`)
+  })
+
+  it('returns the url unchanged when nothing redirects', async () => {
+    assert.strictEqual(await resolveRedirect(`${origin}/final`), `${origin}/final`)
+  })
+
+  it('gives up on a redirect loop rather than hanging', async () => {
+    assert.strictEqual(await resolveRedirect(`${origin}/loop`, 3), `${origin}/loop`)
+  })
+
+  it('rejects when the host cannot be reached', async () => {
+    await assert.rejects(request('http://127.0.0.1:1/nowhere'))
+  })
+})

--- a/src/test/utils/Http.test.ts
+++ b/src/test/utils/Http.test.ts
@@ -33,6 +33,10 @@ describe('http', function () {
           res.writeHead(302, { Location: '/loop' })
           return res.end()
         }
+        if (req.url === '/silent') {
+          // Deliberately never answered, to drive the request timeout.
+          return
+        }
         if (req.url === '/boom') {
           res.writeHead(500)
           return res.end('no')
@@ -79,8 +83,20 @@ describe('http', function () {
     assert.strictEqual(await resolveRedirect(`${origin}/final`), `${origin}/final`)
   })
 
-  it('gives up on a redirect loop rather than hanging', async () => {
-    assert.strictEqual(await resolveRedirect(`${origin}/loop`, 3), `${origin}/loop`)
+  // Returning the last url instead would hand getLatestVersion a redirect to
+  // read a version out of, and compare() throws on what it reads.
+  it('rejects a redirect loop rather than reporting where it gave up', async () => {
+    await assert.rejects(
+      resolveRedirect(`${origin}/loop`, 3),
+      /still redirects after 3 hops/
+    )
+  })
+
+  it('rejects when the host accepts the request but never answers', async () => {
+    await assert.rejects(
+      request(`${origin}/silent`, { timeoutMs: 100 }),
+      /No response from .*silent after 100ms/
+    )
   })
 
   it('rejects when the host cannot be reached', async () => {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,75 @@
+import * as http from 'http'
+import * as https from 'https'
+
+export interface HttpResponse {
+  status: number
+  body: string
+  /** Set when the response is a redirect. */
+  location?: string
+}
+
+function clientFor (url: string): typeof http | typeof https {
+  return new URL(url).protocol === 'http:' ? http : https
+}
+
+/**
+ * A minimal HTTP client over Node's own modules.
+ *
+ * node-fetch became ESM-only at v3 and cannot be required from this extension,
+ * which compiles to CommonJS, and the global fetch is not available in the
+ * Node that older VS Code builds ship. Two requests do not justify either
+ * constraint.
+ */
+export async function request (
+  url: string,
+  options: { method?: string, body?: string, headers?: Record<string, string> } = {}
+): Promise<HttpResponse> {
+  return new Promise<HttpResponse>((resolve, reject) => {
+    const headers = { ...options.headers }
+    if (options.body !== undefined) {
+      // Node would otherwise send the body chunked, which Ollama accepts but
+      // some servers reject outright. No test covers this, because chunked
+      // works against a Node test server either way.
+      headers['Content-Length'] = String(Buffer.byteLength(options.body))
+    }
+    const call = clientFor(url).request(url, { method: options.method ?? 'GET', headers }, response => {
+      let body = ''
+      response.setEncoding('utf8')
+      response.on('data', chunk => { body += chunk })
+      response.on('end', () => resolve({
+        status: response.statusCode ?? 0,
+        body,
+        location: response.headers.location
+      }))
+    })
+    call.on('error', reject)
+    if (options.body !== undefined) {
+      call.write(options.body)
+    }
+    call.end()
+  })
+}
+
+/**
+ * Follows redirects and reports where they land, which is how the latest
+ * release version is discovered.
+ */
+export async function resolveRedirect (url: string, maxHops = 5): Promise<string> {
+  let current = url
+  for (let hop = 0; hop < maxHops; hop++) {
+    const response = await request(current, { method: 'HEAD' })
+    if (response.status < 300 || response.status >= 400 || response.location === undefined) {
+      return current
+    }
+    current = new URL(response.location, current).toString()
+  }
+  return current
+}
+
+export async function postJson (url: string, payload: unknown): Promise<HttpResponse> {
+  return request(url, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: { 'Content-Type': 'application/json' }
+  })
+}

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -8,6 +8,8 @@ export interface HttpResponse {
   location?: string
 }
 
+const DEFAULT_TIMEOUT_MS = 30000
+
 function clientFor (url: string): typeof http | typeof https {
   return new URL(url).protocol === 'http:' ? http : https
 }
@@ -22,8 +24,14 @@ function clientFor (url: string): typeof http | typeof https {
  */
 export async function request (
   url: string,
-  options: { method?: string, body?: string, headers?: Record<string, string> } = {}
+  options: {
+    method?: string
+    body?: string
+    headers?: Record<string, string>
+    timeoutMs?: number
+  } = {}
 ): Promise<HttpResponse> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
   return new Promise<HttpResponse>((resolve, reject) => {
     const headers = { ...options.headers }
     if (options.body !== undefined) {
@@ -42,6 +50,11 @@ export async function request (
         location: response.headers.location
       }))
     })
+    // Without this an unresponsive host holds the install spinner open with no
+    // way for the user to cancel it.
+    call.setTimeout(timeoutMs, () => {
+      call.destroy(new Error(`No response from ${url} after ${timeoutMs}ms`))
+    })
     call.on('error', reject)
     if (options.body !== undefined) {
       call.write(options.body)
@@ -53,6 +66,9 @@ export async function request (
 /**
  * Follows redirects and reports where they land, which is how the latest
  * release version is discovered.
+ *
+ * @throws when the redirects outlast `maxHops`, since the last url reached is
+ * still a redirect and callers would read a version out of it.
  */
 export async function resolveRedirect (url: string, maxHops = 5): Promise<string> {
   let current = url
@@ -63,7 +79,7 @@ export async function resolveRedirect (url: string, maxHops = 5): Promise<string
     }
     current = new URL(response.location, current).toString()
   }
-  return current
+  throw new Error(`${url} still redirects after ${maxHops} hops`)
 }
 
 export async function postJson (url: string, payload: unknown): Promise<HttpResponse> {

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -4,8 +4,15 @@ import { resolveEsbmcCommand } from './esbmcPath'
 
 // The latest release redirects to its own tag, so the tag is the version.
 export async function getLatestVersion (): Promise<string | undefined> {
-  const landed = await resolveRedirect('https://github.com/esbmc/esbmc/releases/latest')
-  return landed.split('/').pop()?.replace('v', '')
+  try {
+    const landed = await resolveRedirect('https://github.com/esbmc/esbmc/releases/latest')
+    return landed.split('/').pop()?.replace('v', '')
+  } catch {
+    // Unreachable host or an unresolved redirect. Callers report this as
+    // "could not fetch latest version"; a url read as a version would reach
+    // compare() and throw there instead.
+    return undefined
+  }
 }
 
 export async function getInstalledVersion (): Promise<string | undefined> {

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -1,12 +1,11 @@
-import { Request, default as fetch } from 'node-fetch'
 import { runShellCommand } from './commands'
+import { resolveRedirect } from './http'
 import { resolveEsbmcCommand } from './esbmcPath'
 
-export async function getLatestVersion () {
-  const request = new Request('https://github.com/esbmc/esbmc/releases/latest')
-  const response = await fetch(request)
-  const redirUrl = response.url
-  return redirUrl.split('/').pop()?.replace('v', '')
+// The latest release redirects to its own tag, so the tag is the version.
+export async function getLatestVersion (): Promise<string | undefined> {
+  const landed = await resolveRedirect('https://github.com/esbmc/esbmc/releases/latest')
+  return landed.split('/').pop()?.replace('v', '')
 }
 
 export async function getInstalledVersion (): Promise<string | undefined> {


### PR DESCRIPTION
Three Dependabot PRs are red and cannot be merged as-is. Two of them — #29 (`flatten-anything` 3→4) and #30 (`node-fetch` 2→3) — fail for the same reason: both packages became `"type": "module"` in that major, and this extension compiles to CommonJS, so `require()` of them throws at runtime. Pinning the majors forever would mean Dependabot re-proposing a breaking update every week.

So both are removed instead:

- **`node-fetch`** — two call sites. They now use Node's own `http`/`https` through a small client. I deliberately did *not* switch to the global `fetch`, which would have forced the `engines.vscode` floor up from `^1.68` to get a Node that has it.
- **`flatten-anything`** — one call site, flattening nested settings into dotted keys. Replaced with fifteen lines, and the tests are the behaviour **recorded from the real dependency** across eight cases including the non-obvious ones (an empty object is kept as a value; arrays are not descended into).

I verified `getLatestVersion` still returns the same answer against real GitHub: `8.4`, matching what the releases API reports.

This should let #29 and #30 be closed. #28 (13 dev-dependency updates) is a separate problem — it is an ESLint 9/10 flat-config migration and wants its own change.

Side effect worth noting: removing these takes their whole dependency trees too. The VSIX goes from 418 files (422 KB) to 111 files (119 KB), and `npm audit` still reports zero.

110 tests passing headlessly; mutation-checked with 9 mutations, 8 caught — the survivor is the `Content-Length` header, which is a compatibility belt rather than a correctness requirement, and the code says so.

Stacked on #39.