### PR TITLE
Expose ESBMC to agents through an MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Added
 
+- An MCP server exposing a `verify` tool, so agents in Claude Code, Cursor,
+  Copilot agent mode and Cline can run ESBMC and read the counterexample
+  without going through the editor. Verification itself moved into a module
+  free of any VS Code import, which the editor commands and the server share.
+
 - Violated properties are reported as diagnostics: squiggles on the failing
   line and entries in the Problems panel, read from ESBMC SARIF output rather
   than scraped from the log.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ and **AI Integration** in the Settings UI. Each value documents the flag it
 produces. Only settings that differ from their default emit anything, which is
 why **ESBMC: Show current flags** exists.
 
+## Use ESBMC from an AI agent
+
+The extension ships an MCP server exposing a `verify` tool, so agents in
+Claude Code, Cursor, Copilot agent mode and Cline can run ESBMC themselves and
+read the counterexample. Point the agent at the entry point inside the
+installed extension:
+
+```json
+{
+  "mcpServers": {
+    "esbmc": {
+      "command": "node",
+      "args": ["<extension-path>/out/mcp/main.js"]
+    }
+  }
+}
+```
+
+`<extension-path>` is what **Developer: Show Running Extensions** reports for
+this extension. The tool takes a `file`, and optionally `flags` and
+`timeoutSeconds`; it answers with the verdict, each violated property and its
+location, and the counterexample trace.
+
 ## Remote development
 
 The extension declares `extensionKind: ["workspace"]`, so with **Remote-SSH**,

--- a/package-lock.json
+++ b/package-lock.json
@@ -606,6 +606,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2595,10 +2611,13 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3227,14 +3246,72 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4211,6 +4288,16 @@
       "requires": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "callsites": {
@@ -5643,9 +5730,9 @@
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true
     },
     "object-keys": {
@@ -6063,14 +6150,51 @@
       "dev": true
     },
     "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      }
+    },
+    "side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      }
+    },
+    "side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       }
     },
     "signal-exit": {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,17 +1,12 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs'
-import * as os from 'os'
 import * as path from 'path'
 import { ConfigurationParser } from '../parsers/configParser'
 import { Configuration } from '../@types/vscode.configuration'
-import { quoteShellArg, runShellCommand } from '../utils/commands'
-import { parseSarif, resolveFindingPaths, EsbmcFinding } from '../parsers/sarifParser'
-import { classifyVerdict, statusText } from '../parsers/verdict'
+import { statusText } from '../parsers/verdict'
 import { EsbmcDiagnostics } from '../diagnostics/esbmcDiagnostics'
 import { TraceView } from '../diagnostics/traceView'
-import { parseGraphmlWitness, TraceStep } from '../parsers/witnessParser'
 import { SUPPORTED_EXTENSIONS } from '../languages'
-import { resolveEsbmcCommand } from '../utils/esbmcPath'
+import { EsbmcNotFoundError, VerifyResult, verifyFile } from '../verify'
 import { disposeOutput, esbmcOutput as output } from '../utils/output'
 
 const CONFIG_PARSER: ConfigurationParser = new ConfigurationParser()
@@ -102,11 +97,6 @@ export async function run (overides?: Configuration, commentFlags?: string, docu
     }
   }
 
-  const esbmcCmd = await resolveEsbmcCommand()
-  if (esbmcCmd === undefined) {
-    vscode.window.showErrorMessage('ESBMC: not found, try running "ESBMC: Install latest version"')
-    return
-  }
   const configured = vscode.workspace.getConfiguration('esbmc.editor').get<number>('timeout', 60)
   const timeoutSeconds = Number.isFinite(configured) ? Math.max(0, configured) : 60
 
@@ -122,63 +112,31 @@ export async function run (overides?: Configuration, commentFlags?: string, docu
   channel.clear()
   channel.show(true)
 
-  const workingDir = path.dirname(filePath)
-  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-'))
-  const report = path.join(reportDir, 'result.sarif')
-  const witness = path.join(reportDir, 'witness.graphml')
+  let result: VerifyResult
   try {
-    const cmd = `${esbmcCmd} ${quoteShellArg(filePath)} ${flags} --sarif-output ${quoteShellArg(report)} --witness-output-graphml ${quoteShellArg(witness)}`
-    channel.appendLine(cmd)
-
-    const result = await runShellCommand(cmd, {
-      timeoutMs: timeoutSeconds * 1000,
+    result = await verifyFile(filePath, {
+      flags,
+      timeoutSeconds,
       onStart: kill => { killInFlight = kill }
     })
-    if (token !== runToken || disposed) { return }
-    killInFlight = undefined
-
-    channel.append(result.stdout)
-    channel.append(result.stderr)
-
-    const findings = result.timedOut ? [] : resolveFindingPaths(readFindings(report, channel), workingDir)
-    diagnostics().report(findings)
-    trace().show(readTrace(witness))
-
-    // ESBMC prints its verdict on stderr and only its version banner on stdout.
-    showStatus(statusText(classifyVerdict({
-      transcript: result.stdout + result.stderr,
-      findings,
-      timedOut: result.timedOut,
-      timeoutSeconds
-    })))
-    if (result.timedOut) {
-      channel.appendLine(`\nESBMC: killed after ${timeoutSeconds}s (esbmc.editor.timeout)`)
-    }
-  } finally {
-    fs.rmSync(reportDir, { recursive: true, force: true })
-  }
-}
-
-function readTrace (witness: string): TraceStep[] {
-  if (!fs.existsSync(witness)) {
-    return []
-  }
-  try {
-    return parseGraphmlWitness(fs.readFileSync(witness, 'utf8'))
-  } catch {
-    return []
-  }
-}
-
-function readFindings (report: string, channel: vscode.OutputChannel): EsbmcFinding[] {
-  if (!fs.existsSync(report)) {
-    return []
-  }
-  try {
-    return parseSarif(fs.readFileSync(report, 'utf8'))
   } catch (error) {
-    channel.appendLine(`\nESBMC: could not read the SARIF report (${String(error)})`)
-    return []
+    if (token !== runToken || disposed) { return }
+    showStatus('$(question) ESBMC: no verdict')
+    vscode.window.showErrorMessage(error instanceof EsbmcNotFoundError
+      ? 'ESBMC: not found, try running "ESBMC: Install latest version"'
+      : `ESBMC: ${String(error)}`)
+    return
+  }
+  if (token !== runToken || disposed) { return }
+  killInFlight = undefined
+
+  channel.appendLine(result.command)
+  channel.append(result.transcript)
+  diagnostics().report(result.findings)
+  trace().show(result.trace)
+  showStatus(statusText(result.verdict))
+  if (result.verdict.kind === 'timeout') {
+    channel.appendLine(`\nESBMC: killed after ${timeoutSeconds}s (esbmc.editor.timeout)`)
   }
 }
 

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -1,0 +1,4 @@
+import { createServer } from './server'
+
+// Entry point for agents: `node <extension>/out/mcp/main.js` over stdio.
+createServer().listen(process.stdin, process.stdout)

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -1,0 +1,124 @@
+import { Readable, Writable } from 'stream'
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id?: number | string
+  method: string
+  params?: any
+}
+
+export interface ToolDefinition {
+  name: string
+  title: string
+  description: string
+  inputSchema: Record<string, unknown>
+}
+
+export interface ToolResult {
+  content: Array<{ type: 'text', text: string }>
+  isError?: boolean
+}
+
+export interface ServerInfo {
+  name: string
+  version: string
+}
+
+const PROTOCOL_VERSION = '2024-11-05'
+const METHOD_NOT_FOUND = -32601
+const INTERNAL_ERROR = -32603
+
+/**
+ * The MCP stdio surface, which is JSON-RPC 2.0 over newline-delimited JSON.
+ *
+ * Written directly rather than with @modelcontextprotocol/sdk: the SDK pulls
+ * an HTTP framework and a JWT library for transports a stdio server never
+ * uses, which took the packaged extension from 111 files to 4096. Only three
+ * methods are needed, and the tests drive them over a real pipe.
+ */
+interface RegisteredTool {
+  definition: ToolDefinition
+  call: (args: any) => Promise<ToolResult>
+}
+
+export class McpStdioServer {
+  private readonly tools: Map<string, RegisteredTool> = new Map()
+  private readonly info: ServerInfo
+
+  public constructor (info: ServerInfo) {
+    this.info = info
+  }
+
+  public tool (definition: ToolDefinition, call: (args: any) => Promise<ToolResult>): void {
+    this.tools.set(definition.name, { definition, call })
+  }
+
+  /** @returns the reply, or undefined for a notification. */
+  public async handle (request: JsonRpcRequest): Promise<object | undefined> {
+    const reply = (result: object): object => ({ jsonrpc: '2.0', id: request.id, result })
+    const fail = (code: number, message: string): object =>
+      ({ jsonrpc: '2.0', id: request.id, error: { code, message } })
+
+    switch (request.method) {
+      case 'initialize':
+        return reply({
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: this.info
+        })
+      case 'notifications/initialized':
+        return undefined
+      case 'ping':
+        return reply({})
+      case 'tools/list':
+        return reply({ tools: [...this.tools.values()].map(entry => entry.definition) })
+      case 'tools/call': {
+        const tool = this.tools.get(request.params?.name)
+        if (tool === undefined) {
+          return fail(METHOD_NOT_FOUND, `Unknown tool: ${String(request.params?.name)}`)
+        }
+        try {
+          return reply(await tool.call(request.params?.arguments ?? {}))
+        } catch (error) {
+          return fail(INTERNAL_ERROR, String(error))
+        }
+      }
+      default:
+        // A notification we do not implement needs no reply at all.
+        return request.id === undefined ? undefined : fail(METHOD_NOT_FOUND, `Unknown method: ${request.method}`)
+    }
+  }
+
+  /** Reads newline-delimited requests until the input closes. */
+  public listen (input: Readable, output: Writable): void {
+    let buffer = ''
+    input.setEncoding('utf8')
+    input.on('data', chunk => {
+      buffer += chunk
+      let newline = buffer.indexOf('\n')
+      while (newline !== -1) {
+        const line = buffer.slice(0, newline).trim()
+        buffer = buffer.slice(newline + 1)
+        newline = buffer.indexOf('\n')
+        if (line === '') {
+          continue
+        }
+        this.respond(line, output).catch(() => {})
+      }
+    })
+  }
+
+  private async respond (line: string, output: Writable): Promise<void> {
+    let request: JsonRpcRequest
+    try {
+      request = JSON.parse(line)
+    } catch {
+      // A malformed line has no id to answer against, so it is dropped.
+      return
+    }
+    const reply = await this.handle(request)
+    if (reply !== undefined) {
+      output.write(JSON.stringify(reply) + '\n')
+    }
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,15 @@
+import * as fs from 'fs'
+import * as path from 'path'
 import { McpStdioServer } from './protocol'
 import { EsbmcNotFoundError, VerifyResult, verifyFile } from '../verify'
+
+// out/mcp/server.js -> the extension root. The server runs outside VS Code, so
+// there is no extension context to read the manifest from.
+const MANIFEST = path.join(__dirname, '..', '..', 'package.json')
+
+export function serverVersion (): string {
+  return JSON.parse(fs.readFileSync(MANIFEST, 'utf8')).version
+}
 
 /** What an agent gets back, kept stable and independent of ESBMC's log format. */
 export function describeResult (file: string, result: VerifyResult): string {
@@ -44,7 +54,7 @@ export function describeResult (file: string, result: VerifyResult): string {
 }
 
 export function createServer (): McpStdioServer {
-  const server = new McpStdioServer({ name: 'esbmc', version: '0.1.0' })
+  const server = new McpStdioServer({ name: 'esbmc', version: serverVersion() })
 
   server.tool(
     {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,85 @@
+import { McpStdioServer } from './protocol'
+import { EsbmcNotFoundError, VerifyResult, verifyFile } from '../verify'
+
+/** What an agent gets back, kept stable and independent of ESBMC's log format. */
+export function describeResult (file: string, result: VerifyResult): string {
+  const lines: string[] = []
+  switch (result.verdict.kind) {
+    case 'success':
+      lines.push(`VERIFICATION SUCCESSFUL: ESBMC proved every checked property of ${file}.`)
+      break
+    case 'violations':
+      lines.push(`VERIFICATION FAILED: ${result.verdict.count} property/properties violated in ${file}.`)
+      break
+    case 'failed-without-findings':
+      lines.push(`VERIFICATION FAILED in ${file}, but ESBMC reported no property to place.`)
+      break
+    case 'timeout':
+      lines.push(`TIMEOUT: ESBMC was killed after ${result.verdict.seconds}s on ${file}.`)
+      break
+    case 'unknown':
+      lines.push(`NO VERDICT: ESBMC did not reach a conclusion on ${file}.`)
+      break
+  }
+
+  for (const finding of result.findings) {
+    const cwes = finding.cwes.length > 0 ? ` [${finding.cwes.join(', ')}]` : ''
+    lines.push(`  ${finding.file}:${finding.line} ${finding.message}${cwes}`)
+  }
+
+  if (result.trace.length > 0) {
+    lines.push('', 'Counterexample:')
+    for (const step of result.trace) {
+      const where = step.line === undefined ? '' : `${step.file ?? ''}:${step.line} `
+      const what = step.assumptions.length > 0
+        ? step.assumptions.join(', ')
+        : step.enterFunction === undefined ? '' : `enter ${step.enterFunction}`
+      if (where !== '' || what !== '') {
+        lines.push(`  ${where}${what}`.trimEnd())
+      }
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export function createServer (): McpStdioServer {
+  const server = new McpStdioServer({ name: 'esbmc', version: '0.1.0' })
+
+  server.tool(
+    {
+      name: 'verify',
+      title: 'Verify with ESBMC',
+      description:
+        'Run ESBMC, a bounded model checker, over a C, C++, Python or Solidity file. ' +
+        'Reports each violated property with its location, and a counterexample trace ' +
+        'with the variable values that reach it. A successful result means no execution ' +
+        'violates the checked properties, not merely that none was found.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          file: { type: 'string', description: 'Absolute path to the file to verify' },
+          flags: { type: 'string', description: 'Extra ESBMC flags, for example --unwind 10 --overflow-check' },
+          timeoutSeconds: { type: 'number', description: 'Kill the run after this long, 0 waits indefinitely' }
+        },
+        required: ['file']
+      }
+    },
+    async ({ file, flags, timeoutSeconds }) => {
+      if (typeof file !== 'string' || file === '') {
+        return { isError: true, content: [{ type: 'text' as const, text: 'verify needs a file path' }] }
+      }
+      try {
+        const result = await verifyFile(file, { flags, timeoutSeconds })
+        return { content: [{ type: 'text' as const, text: describeResult(file, result) }] }
+      } catch (error) {
+        const message = error instanceof EsbmcNotFoundError
+          ? 'ESBMC is not installed. Install it from https://github.com/esbmc/esbmc/releases or through the VS Code extension.'
+          : `Could not verify ${file}: ${String(error)}`
+        return { isError: true, content: [{ type: 'text' as const, text: message }] }
+      }
+    }
+  )
+
+  return server
+}

--- a/src/test/mcp/Protocol.test.ts
+++ b/src/test/mcp/Protocol.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert'
+import { McpStdioServer } from '../../mcp/protocol'
+
+function server (): McpStdioServer {
+  const mcp = new McpStdioServer({ name: 'esbmc', version: '0.1.0' })
+  mcp.tool(
+    { name: 'echo', title: 'Echo', description: 'echoes', inputSchema: { type: 'object' } },
+    async (args: any) => ({ content: [{ type: 'text' as const, text: String(args.text) }] })
+  )
+  return mcp
+}
+
+describe('McpStdioServer', () => {
+  it('answers initialize with its capabilities and identity', async () => {
+    const reply: any = await server().handle({ jsonrpc: '2.0', id: 1, method: 'initialize' })
+    assert.strictEqual(reply.id, 1)
+    assert.strictEqual(reply.result.serverInfo.name, 'esbmc')
+    assert.deepStrictEqual(reply.result.capabilities, { tools: {} })
+    assert.match(reply.result.protocolVersion, /^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  // A notification has no id, so answering one would be a protocol violation.
+  it('says nothing to a notification', async () => {
+    assert.strictEqual(await server().handle({ jsonrpc: '2.0', method: 'notifications/initialized' }), undefined)
+    assert.strictEqual(await server().handle({ jsonrpc: '2.0', method: 'notifications/unknown' }), undefined)
+  })
+
+  it('lists registered tools', async () => {
+    const reply: any = await server().handle({ jsonrpc: '2.0', id: 2, method: 'tools/list' })
+    assert.deepStrictEqual(reply.result.tools.map((t: any) => t.name), ['echo'])
+  })
+
+  it('calls a tool with its arguments', async () => {
+    const reply: any = await server().handle({
+      jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'echo', arguments: { text: 'hi' } }
+    })
+    assert.deepStrictEqual(reply.result.content, [{ type: 'text', text: 'hi' }])
+  })
+
+  it('reports an unknown tool as an error, not a crash', async () => {
+    const reply: any = await server().handle({
+      jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'nope' }
+    })
+    assert.strictEqual(reply.error.code, -32601)
+  })
+
+  it('turns a throwing tool into an internal error', async () => {
+    const mcp = new McpStdioServer({ name: 'esbmc', version: '0.1.0' })
+    mcp.tool({ name: 'bad', title: 'Bad', description: '', inputSchema: {} }, async () => { throw Error('boom') })
+    const reply: any = await mcp.handle({ jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'bad' } })
+    assert.strictEqual(reply.error.code, -32603)
+    assert.match(reply.error.message, /boom/)
+  })
+
+  it('rejects an unknown request but not an unknown notification', async () => {
+    const reply: any = await server().handle({ jsonrpc: '2.0', id: 6, method: 'nope' })
+    assert.strictEqual(reply.error.code, -32601)
+  })
+
+  it('answers ping', async () => {
+    const reply: any = await server().handle({ jsonrpc: '2.0', id: 7, method: 'ping' })
+    assert.deepStrictEqual(reply.result, {})
+  })
+})

--- a/src/test/mcp/Server.test.ts
+++ b/src/test/mcp/Server.test.ts
@@ -1,0 +1,153 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process'
+import { describeResult } from '../../mcp/server'
+import { VerifyResult } from '../../verify'
+
+const MAIN = path.resolve(__dirname, '..', '..', 'mcp', 'main.js')
+
+/** Speaks just enough JSON-RPC over stdio to act as an MCP client. */
+class StdioClient {
+  private readonly child: ChildProcessWithoutNullStreams
+  private buffer = ''
+  private readonly pending: Map<number, (message: any) => void> = new Map()
+
+  public constructor () {
+    this.child = spawn(process.execPath, [MAIN], { stdio: 'pipe' })
+    this.child.stdout.setEncoding('utf8')
+    this.child.stdout.on('data', chunk => {
+      this.buffer += chunk
+      let newline = this.buffer.indexOf('\n')
+      while (newline !== -1) {
+        const line = this.buffer.slice(0, newline).trim()
+        this.buffer = this.buffer.slice(newline + 1)
+        if (line !== '') {
+          const message = JSON.parse(line)
+          this.pending.get(message.id)?.(message)
+          this.pending.delete(message.id)
+        }
+        newline = this.buffer.indexOf('\n')
+      }
+    })
+  }
+
+  public async send (id: number, method: string, params: unknown = {}): Promise<any> {
+    return new Promise(resolve => {
+      this.pending.set(id, resolve)
+      this.child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
+    })
+  }
+
+  public notify (method: string, params: unknown = {}): void {
+    this.child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n')
+  }
+
+  public close (): void {
+    this.child.kill()
+  }
+}
+
+describe('MCP server over stdio', function () {
+  this.timeout(120000)
+
+  let client: StdioClient
+
+  before(async () => {
+    client = new StdioClient()
+    await client.send(1, 'initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0' }
+    })
+    client.notify('notifications/initialized')
+  })
+
+  after(() => client?.close())
+
+  it('introduces itself as esbmc', async () => {
+    const fresh = new StdioClient()
+    const reply = await fresh.send(1, 'initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0' }
+    })
+    fresh.close()
+    assert.strictEqual(reply.result.serverInfo.name, 'esbmc')
+  })
+
+  it('advertises the verify tool and what it takes', async () => {
+    const reply = await client.send(2, 'tools/list')
+    const tool = reply.result.tools.find((t: any) => t.name === 'verify')
+    assert.ok(tool, `verify not advertised in ${JSON.stringify(reply.result.tools)}`)
+    assert.deepStrictEqual(Object.keys(tool.inputSchema.properties).sort(), ['file', 'flags', 'timeoutSeconds'])
+    assert.deepStrictEqual(tool.inputSchema.required, ['file'])
+  })
+
+  it('reports a violation with its location', async function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-mcp-'))
+    const file = path.join(dir, 'fails.c')
+    fs.writeFileSync(file, 'int main(void)\n{\n  int v[4];\n  for (int i = 0; i <= 4; i++)\n    v[i] = i;\n  return 0;\n}\n')
+    try {
+      const reply = await client.send(3, 'tools/call', { name: 'verify', arguments: { file } })
+      const text: string = reply.result.content[0].text
+      if (/not installed/.test(text)) {
+        return this.skip()
+      }
+      assert.match(text, /VERIFICATION FAILED/)
+      assert.match(text, /array bounds/)
+      assert.match(text, new RegExp(`${file.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:5`))
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a missing file as a tool error rather than crashing', async () => {
+    const reply = await client.send(4, 'tools/call', {
+      name: 'verify',
+      arguments: { file: '/nonexistent/nope.c' }
+    })
+    assert.ok(reply.result.isError === true || /not installed|Could not verify|FAILED|NO VERDICT/.test(reply.result.content[0].text))
+  })
+})
+
+describe('describeResult', () => {
+  function result (overrides: Partial<VerifyResult> = {}): VerifyResult {
+    return {
+      verdict: { kind: 'success' },
+      findings: [],
+      trace: [],
+      transcript: '',
+      command: 'esbmc a.c',
+      ...overrides
+    }
+  }
+
+  it('states plainly what a successful result means', () => {
+    assert.match(describeResult('a.c', result()), /VERIFICATION SUCCESSFUL/)
+  })
+
+  it('lists each violated property with its location', () => {
+    const text = describeResult('a.c', result({
+      verdict: { kind: 'violations', count: 1 },
+      findings: [{ file: '/src/a.c', line: 5, message: 'array bounds violated', severity: 'error', cwes: ['CWE-787'] }]
+    }))
+    assert.match(text, /VERIFICATION FAILED: 1 property/)
+    assert.match(text, /\/src\/a\.c:5 array bounds violated \[CWE-787\]/)
+  })
+
+  it('includes the counterexample values', () => {
+    const text = describeResult('a.c', result({
+      verdict: { kind: 'violations', count: 1 },
+      trace: [{ file: '/src/a.c', line: 4, assumptions: ['x == 11'] }]
+    }))
+    assert.match(text, /Counterexample:/)
+    assert.match(text, /\/src\/a\.c:4 x == 11/)
+  })
+
+  it('distinguishes a timeout from a failure', () => {
+    assert.match(describeResult('a.c', result({ verdict: { kind: 'timeout', seconds: 5 } })), /TIMEOUT/)
+    assert.doesNotMatch(describeResult('a.c', result({ verdict: { kind: 'timeout', seconds: 5 } })), /FAILED/)
+  })
+})

--- a/src/test/mcp/Server.test.ts
+++ b/src/test/mcp/Server.test.ts
@@ -103,6 +103,47 @@ describe('MCP server over stdio', function () {
     }
   })
 
+  // flags arrives verbatim from agent input and the command reaches a shell, so
+  // an unquoted token would run as a command of its own. Each payload has to
+  // stand alone: ESBMC's own flags follow it on the command line, and a bare
+  // `; touch MARKER` would collect them as arguments and fail before creating
+  // anything, hiding the very injection this pins down.
+  it('runs no command hidden in the flags an agent passes', async function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-mcp-'))
+    const file = path.join(dir, 'ok.c')
+    fs.writeFileSync(file, 'int main(void) { return 0; }\n')
+    try {
+      let id = 5
+      for (const shape of ['$(touch MARKER)', '`touch MARKER`', '; touch MARKER #']) {
+        const marker = path.join(dir, `pwned-${id}`)
+        const reply = await client.send(id++, 'tools/call', {
+          name: 'verify',
+          arguments: { file, flags: shape.replace('MARKER', marker) }
+        })
+        if (/not installed/.test(reply.result.content[0].text)) {
+          return this.skip()
+        }
+        assert.ok(!fs.existsSync(marker), `${shape} ran`)
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reports its version from the manifest rather than a literal', async () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', '..', '..', 'package.json'), 'utf8')
+    )
+    const fresh = new StdioClient()
+    const reply = await fresh.send(1, 'initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0' }
+    })
+    fresh.close()
+    assert.strictEqual(reply.result.serverInfo.version, manifest.version)
+  })
+
   it('reports a missing file as a tool error rather than crashing', async () => {
     const reply = await client.send(4, 'tools/call', {
       name: 'verify',

--- a/src/test/utils/quoteShellArg.test.ts
+++ b/src/test/utils/quoteShellArg.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { quoteShellArg, runShellCommand } from '../../utils/commands'
+import { quoteShellArg, runShellCommand, splitShellArgs } from '../../utils/commands'
 
 // Quoting must follow the platform it is asked about, not the one the tests
 // run on: extractCommand builds a Linux unzip command on any host.
@@ -68,5 +68,67 @@ describe('quoteShellArg', function () {
   it('leaves a command substitution intact as literal text', async () => {
     const result = await runShellCommand(`printf %s ${quoteShellArg('$(echo hi)')}`)
     assert.strictEqual(result.stdout, '$(echo hi)')
+  })
+})
+
+// ESBMC flags arrive as one string, from settings or from MCP agent input, and
+// are re-quoted token by token before reaching a shell.
+describe('splitShellArgs', () => {
+  it('splits on whitespace', () => {
+    assert.deepStrictEqual(splitShellArgs('--unwind 10 --overflow-check'), ['--unwind', '10', '--overflow-check'])
+  })
+
+  it('reports nothing for an empty or blank string', () => {
+    assert.deepStrictEqual(splitShellArgs(''), [])
+    assert.deepStrictEqual(splitShellArgs('   \t '), [])
+  })
+
+  it('keeps a quoted value together and drops the quotes', () => {
+    assert.deepStrictEqual(splitShellArgs('--claim "two words"'), ['--claim', 'two words'])
+    assert.deepStrictEqual(splitShellArgs("--claim 'two words'"), ['--claim', 'two words'])
+  })
+
+  it('keeps an empty quoted argument', () => {
+    assert.deepStrictEqual(splitShellArgs('--claim ""'), ['--claim', ''])
+  })
+
+  it('leaves a Windows path alone', () => {
+    assert.deepStrictEqual(splitShellArgs('--include C:\\a\\b'), ['--include', 'C:\\a\\b'])
+  })
+
+  it('holds a separator inside its token instead of ending the command', () => {
+    assert.deepStrictEqual(splitShellArgs('--unwind 1; rm -rf x'), ['--unwind', '1;', 'rm', '-rf', 'x'])
+  })
+})
+
+// The composition is what makes hostile flags safe: split groups the tokens,
+// quoting neutralises what is inside each one.
+describe('splitShellArgs with quoteShellArg', function () {
+  this.timeout(60000)
+
+  let dir: string
+
+  before(function () {
+    if (process.platform === 'win32') {
+      this.skip()
+    }
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-split-'))
+  })
+
+  after(() => {
+    if (dir !== undefined) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('runs no command smuggled in through a flag string', async () => {
+    for (const shape of ['; touch MARKER', '&& touch MARKER', '$(touch MARKER)', '`touch MARKER`']) {
+      const marker = path.join(dir, `pwned-${shape.replace(/\W/g, '')}`)
+      const flags = splitShellArgs(shape.replace('MARKER', marker))
+        .map(flag => quoteShellArg(flag))
+        .join(' ')
+      await runShellCommand(`printf %s ${flags}`)
+      assert.strictEqual(fs.existsSync(marker), false, `${shape} ran`)
+    }
   })
 })

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -34,6 +34,44 @@ export function quoteShellArg (value: string, platform: string = process.platfor
   return `'${value.replace(/'/g, "'\\''")}'`
 }
 
+/**
+ * Splits a command line into the arguments a shell would group it into,
+ * honouring quotes but leaving every other metacharacter inside its token.
+ *
+ * Callers re-quote each argument with quoteShellArg, so a value carrying
+ * `;`, `&&` or `$(...)` ends up as one literal ESBMC flag rather than a
+ * command of its own. Backslashes are left alone, so Windows paths survive.
+ */
+export function splitShellArgs (value: string): string[] {
+  const args: string[] = []
+  let current = ''
+  let started = false
+  let quote: string | undefined
+
+  for (const char of value) {
+    if (quote === undefined && /\s/.test(char)) {
+      if (started) {
+        args.push(current)
+        current = ''
+        started = false
+      }
+      continue
+    }
+    started = true
+    if (quote === undefined && (char === "'" || char === '"')) {
+      quote = char
+    } else if (char === quote) {
+      quote = undefined
+    } else {
+      current += char
+    }
+  }
+  if (started) {
+    args.push(current)
+  }
+  return args
+}
+
 export interface CommandResult {
   stdout: string
   stderr: string

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { quoteShellArg, runShellCommand } from './utils/commands'
+import { resolveEsbmcCommand } from './utils/esbmcPath'
+import { EsbmcFinding, parseSarif, resolveFindingPaths } from './parsers/sarifParser'
+import { TraceStep, parseGraphmlWitness } from './parsers/witnessParser'
+import { Verdict, classifyVerdict } from './parsers/verdict'
+
+export interface VerifyOptions {
+  /** Extra ESBMC flags, already joined as a command line. */
+  flags?: string
+  /** Kill the run after this long; 0 waits indefinitely. */
+  timeoutSeconds?: number
+  /** Receives a kill function as soon as ESBMC starts. */
+  onStart?: (kill: () => void) => void
+}
+
+export interface VerifyResult {
+  verdict: Verdict
+  findings: EsbmcFinding[]
+  trace: TraceStep[]
+  /** Both ESBMC streams joined; its verdict goes to stderr. */
+  transcript: string
+  command: string
+}
+
+export class EsbmcNotFoundError extends Error {
+  public constructor () {
+    super('ESBMC not found')
+  }
+}
+
+function readIfPresent<T> (file: string, parse: (text: string) => T, fallback: T): T {
+  if (!fs.existsSync(file)) {
+    return fallback
+  }
+  try {
+    return parse(fs.readFileSync(file, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * Runs ESBMC over one file and reports what it found.
+ *
+ * Deliberately free of any VS Code import: the editor commands and the MCP
+ * server are both callers, and only one of them runs inside VS Code.
+ *
+ * @throws EsbmcNotFoundError when ESBMC is not installed anywhere.
+ */
+export async function verifyFile (file: string, options: VerifyOptions = {}): Promise<VerifyResult> {
+  const esbmc = await resolveEsbmcCommand()
+  if (esbmc === undefined) {
+    throw new EsbmcNotFoundError()
+  }
+
+  const timeoutSeconds = Number.isFinite(options.timeoutSeconds)
+    ? Math.max(0, options.timeoutSeconds as number)
+    : 60
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'esbmc-'))
+  const report = path.join(reportDir, 'result.sarif')
+  const witness = path.join(reportDir, 'witness.graphml')
+
+  try {
+    const flags = options.flags === undefined || options.flags === '' ? '' : ` ${options.flags}`
+    const command =
+      `${esbmc} ${quoteShellArg(file)}${flags}` +
+      ` --sarif-output ${quoteShellArg(report)}` +
+      ` --witness-output-graphml ${quoteShellArg(witness)}`
+
+    const run = await runShellCommand(command, {
+      timeoutMs: timeoutSeconds * 1000,
+      onStart: options.onStart
+    })
+
+    const findings = run.timedOut
+      ? []
+      : resolveFindingPaths(readIfPresent(report, parseSarif, []), path.dirname(file))
+    const trace = run.timedOut ? [] : readIfPresent(witness, parseGraphmlWitness, [])
+    const transcript = run.stdout + run.stderr
+
+    return {
+      verdict: classifyVerdict({ transcript, findings, timedOut: run.timedOut, timeoutSeconds }),
+      findings,
+      trace,
+      transcript,
+      command
+    }
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true })
+  }
+}

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { quoteShellArg, runShellCommand } from './utils/commands'
+import { quoteShellArg, runShellCommand, splitShellArgs } from './utils/commands'
 import { resolveEsbmcCommand } from './utils/esbmcPath'
 import { EsbmcFinding, parseSarif, resolveFindingPaths } from './parsers/sarifParser'
 import { TraceStep, parseGraphmlWitness } from './parsers/witnessParser'
@@ -64,11 +64,18 @@ export async function verifyFile (file: string, options: VerifyOptions = {}): Pr
   const witness = path.join(reportDir, 'witness.graphml')
 
   try {
-    const flags = options.flags === undefined || options.flags === '' ? '' : ` ${options.flags}`
-    const command =
-      `${esbmc} ${quoteShellArg(file)}${flags}` +
-      ` --sarif-output ${quoteShellArg(report)}` +
-      ` --witness-output-graphml ${quoteShellArg(witness)}`
+    // Flags reach here from agent input through the MCP verify tool, and the
+    // command is handed to a shell, so every token is quoted as a literal.
+    const flags = splitShellArgs(options.flags ?? '').map(flag => quoteShellArg(flag))
+    const command = [
+      esbmc,
+      quoteShellArg(file),
+      ...flags,
+      '--sarif-output',
+      quoteShellArg(report),
+      '--witness-output-graphml',
+      quoteShellArg(witness)
+    ].join(' ')
 
     const run = await runShellCommand(command, {
       timeoutMs: timeoutSeconds * 1000,


### PR DESCRIPTION
Issue #19 lists three things. This does the third — the MCP server — because it is the one that needs no VS Code engine bump and can be tested end to end. The chat participant (item 1) needs the Chat API and a floor well above the current `engines.vscode: ^1.68`, and the ESBMC-AI backend (item 2) is a separate integration; both remain open.

Agents in Claude Code, Cursor, Copilot agent mode and Cline can now call a `verify` tool over stdio and get the verdict, each violated property with its location, and the counterexample trace.

**Verification moved into `src/verify.ts`, free of any VS Code import.** The editor commands and the MCP server are both callers, and only one runs inside VS Code. `run.ts` is now the presentation layer over it, so there is one verification path rather than two that can drift — the seam an earlier review on #26 asked for.

**On the SDK.** I started with `@modelcontextprotocol/sdk`, and the tests below passed against it. But it pulls `hono` (an HTTP framework) and `jose` (JWT) for transports a stdio server never uses: the packaged extension went from **111 files / 119 KB to 4096 files / 5.06 MB**, and vsce started warning about bundling. Right after #40 and #41 spent effort on exactly this, that was hard to justify for three JSON-RPC methods. The protocol is written directly instead, and the VSIX is back to 115 files / 124 KB.

That is a real tradeoff and yours to overrule: the SDK would track future protocol revisions for us. What makes it defensible is that the *same* stdio tests pass against both implementations — they drive a real pipe through the real handshake, not a mock.

129 tests passing headlessly; 12 mutations across the protocol and the tool, all caught. `npm audit` at zero.

Stacked on #41.