### PR TITLE
Read workspace settings, not just user settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Fixed
 
+- Settings set in a workspace or folder `settings.json` were silently ignored:
+  the flag parser read only the user scope, so a per-project unwind bound or
+  solver choice did nothing. All three scopes are now read, narrowest winning.
+- The `esbmc.frontEnd.includeAfter` description linked `#esbmc.includePath#`,
+  which is not a setting id, so it rendered as raw text instead of a link.
+
 - File paths are shell-quoted, so a name containing `$(...)` no longer runs as
   a command. This was reachable by saving a file with `verifyOnSave` enabled.
 

--- a/package.json
+++ b/package.json
@@ -36,18 +36,21 @@
           "esbmc.frontEnd.includePath": {
             "type": "string",
             "markdownDescription": "Sets include path to a given value",
-            "order": 1
+            "order": 1,
+            "scope": "resource"
           },
           "esbmc.frontEnd.includeAfter": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable system include path to search after system headers, `#esbmc.frontEnd.includePath#` must be set if enabled",
-            "order": 2
+            "order": 2,
+            "scope": "resource"
           },
           "esbmc.frontEnd.defineMacros": {
             "type": "string",
             "markdownDescription": "Define preprocessor macro",
-            "order": 3
+            "order": 3,
+            "scope": "resource"
           },
           "esbmc.frontEnd.programLoopClaimVcs": {
             "type": "string",
@@ -71,13 +74,15 @@
               "Show the verification conditions (`--show-vcc`)"
             ],
             "markdownDescription": "Stop the front end after a given stage, or show the program's loops, claims or verification conditions instead of verifying it",
-            "order": 4
+            "order": 4,
+            "scope": "resource"
           },
           "esbmc.frontEnd.claimRemoval": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable the removal of claims",
-            "order": 5
+            "order": 5,
+            "scope": "resource"
           },
           "esbmc.frontEnd.wordLength": {
             "type": "number",
@@ -93,7 +98,8 @@
               "Treat the machine word as 64 bits wide"
             ],
             "markdownDescription": "Set width of machine word",
-            "order": 6
+            "order": 6,
+            "scope": "resource"
           },
           "esbmc.frontEnd.architecture": {
             "type": "string",
@@ -111,7 +117,8 @@
               "Set Windows/I386 architecture (`--i386-win32`)"
             ],
             "markdownDescription": "Set the machine architecture",
-            "order": 7
+            "order": 7,
+            "scope": "resource"
           },
           "esbmc.frontEnd.endianness": {
             "type": "string",
@@ -127,7 +134,8 @@
               "Allow big-endian word-byte conversions (`--big-endian`)"
             ],
             "markdownDescription": "Sets the endianness for word-byte conversions",
-            "order": 8
+            "order": 8,
+            "scope": "resource"
           },
           "esbmc.frontEnd.printingOptions": {
             "type": "string",
@@ -169,13 +177,15 @@
               "Show the SMT model if the formula is satisfiable; not supported by all solvers (`--smt-model`)"
             ],
             "markdownDescription": "Sets the printing options for the ESBMC frontend",
-            "order": 9
+            "order": 9,
+            "scope": "resource"
           },
           "esbmc.frontEnd.resultOnly": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable the printing of the counterexample",
-            "order": 10
+            "order": 10,
+            "scope": "resource"
           }
         }
       },
@@ -241,7 +251,8 @@
             },
             "additionalProperties": false,
             "markdownDescription": "Enable or disable certain trace options",
-            "order": 0
+            "order": 0,
+            "scope": "resource"
           }
         }
       },
@@ -254,84 +265,98 @@
             "type": "string",
             "default": "main",
             "markdownDescription": "Set main function name",
-            "order": 1
+            "order": 1,
+            "scope": "resource"
           },
           "esbmc.bmc.claim": {
             "type": "number",
             "default": -1,
             "markdownDescription": "Only check a specific claim, a value of `-1` indicates checking all claims",
-            "order": 2
+            "order": 2,
+            "scope": "resource"
           },
           "esbmc.bmc.instruction": {
             "type": "number",
             "default": -1,
             "markdownDescription": "Limit the number of instructions executed during symbolic execution, a value of `-1` enforces no limit",
-            "order": 3
+            "order": 3,
+            "scope": "resource"
           },
           "esbmc.bmc.unwind": {
             "type": "number",
             "default": -1,
             "markdownDescription": "Unwind all loops a given number of times a value of `-1` enforces no limit",
-            "order": 4
+            "order": 4,
+            "scope": "resource"
           },
           "esbmc.bmc.unwindSet": {
             "type": "number",
             "markdownDescription": "Unwind a specific loop a given number of times",
-            "order": 5
+            "order": 5,
+            "scope": "resource"
           },
           "esbmc.bmc.unwindingAssertions": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Enable or disable the generation of unwinding assertions",
-            "order": 6
+            "order": 6,
+            "scope": "resource"
           },
           "esbmc.bmc.partialUnwinding": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable the permision of paths with partial loops",
-            "order": 7
+            "order": 7,
+            "scope": "resource"
           },
           "esbmc.bmc.sliceEquations": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Enable or disable the removal of unused equations",
-            "order": 8
+            "order": 8,
+            "scope": "resource"
           },
           "esbmc.bmc.initializeNondetVariables": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable the initialization of declarations with nondet expression, if it hasn`t a default value",
-            "order": 9
+            "order": 9,
+            "scope": "resource"
           },
           "esbmc.bmc.gotoUnwinding": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or unroll bounded loops at goto level",
-            "order": 10
+            "order": 10,
+            "scope": "resource"
           },
           "esbmc.bmc.sliceAssumes": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable the removal of unused assume statements",
-            "order": 11
+            "order": 11,
+            "scope": "resource"
           },
           "esbmc.bmc.incrementalBmc": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable the use of incremental loop unwinding verification",
-            "order": 12
+            "order": 12,
+            "scope": "resource"
           },
           "esbmc.bmc.falsification": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable the use of incremental loop unwinding for bug searching",
-            "order": 13
+            "order": 13,
+            "scope": "resource"
           },
           "esbmc.bmc.termination": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable the use of incremental loop unwinding assertion verification",
-            "order": 14
+            "order": 14,
+            "scope": "resource"
           }
         }
       },
@@ -362,23 +387,27 @@
               "Run an external SMT-LIB solver; set `#esbmc.solver.customSmtSolverPath#` and enable `#esbmc.solver.smtLibFormat#` (`--smtlib --smtlib-solver-prog`)"
             ],
             "markdownDescription": "Sets SMT solver used to model check the program",
-            "order": 1
+            "order": 1,
+            "scope": "resource"
           },
           "esbmc.solver.customSmtSolverPath": {
             "type": "string",
             "markdownDescription": "Sets the program path for the custom SMT solver if `#esbmc.solver.smtSolver#` is set to `custom`",
-            "order": 2
+            "order": 2,
+            "scope": "resource"
           },
           "esbmc.solver.smtLibFormat": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable the use of the SMT lib format",
-            "order": 3
+            "order": 3,
+            "scope": "resource"
           },
           "esbmc.solver.vccOutput": {
             "type": "string",
             "markdownDescription": "Sets output file for generated VCCs in SMT lib format",
-            "order": 4
+            "order": 4,
+            "scope": "resource"
           },
           "esbmc.solver.arithmetic": {
             "type": "string",
@@ -394,7 +423,8 @@
               "Use the solver with integer/real arithmetic (`--ir`); unbounded ranges overapproximate machine integers and reals, which can significantly boost performance"
             ],
             "markdownDescription": "Sets arithmetic used by the solver",
-            "order": 5
+            "order": 5,
+            "scope": "resource"
           },
           "esbmc.solver.floatingPointEncoding": {
             "type": "string",
@@ -412,7 +442,8 @@
               "Encode floating-point as bit-vectors (`--fp2bv`); the default for solvers without SMT floating-point support"
             ],
             "markdownDescription": "Sets encoding used for floating point numbers",
-            "order": 6
+            "order": 6,
+            "scope": "resource"
           },
           "esbmc.solver.tupleEncoding": {
             "type": "string",
@@ -428,7 +459,8 @@
               "Encode tuples using ESBMC's tuple-to-symbol API (`--tuple-sym-flattener`)"
             ],
             "markdownDescription": "Sets encoding used for tuples",
-            "order": 7
+            "order": 7,
+            "scope": "resource"
           },
           "esbmc.solver.arrayEncoding": {
             "type": "string",
@@ -442,37 +474,43 @@
               "Encode arrays using ESBMC's array API (`--array-flattener`)"
             ],
             "markdownDescription": "Sets encoding used for arrays",
-            "order": 8
+            "order": 8,
+            "scope": "resource"
           },
           "esbmc.solver.returnValueOptimisation": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Enable or disable return value optimization to compute the stack size",
-            "order": 9
+            "order": 9,
+            "scope": "resource"
           },
           "esbmc.solver.incrementalSmt": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable incremental SMT solving **experimental**",
-            "order": 10
+            "order": 10,
+            "scope": "resource"
           },
           "esbmc.solver.checkThreadGuard": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable checking of the thread guard  during thread exploration **experimental**",
-            "order": 11
+            "order": 11,
+            "scope": "resource"
           },
           "esbmc.solver.checkSymexGuard": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable checking of conditional goto statements during symbolic execution **experimental**",
-            "order": 12
+            "order": 12,
+            "scope": "resource"
           },
           "esbmc.solver.checkSymexAsserts": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable checking of assertion statements during symbolic execution **experimental**",
-            "order": 13
+            "order": 13,
+            "scope": "resource"
           }
         }
       },
@@ -579,19 +617,21 @@
             },
             "additionalProperties": false,
             "markdownDescription": "Enable or disable checking of certain properties",
-            "scope": "window",
+            "scope": "resource",
             "order": 1
           },
           "esbmc.propertyChecking.checkStackLimit": {
             "type": "number",
             "default": -1,
             "markdownDescription": "Check that the stack limit is respected, a value of `-1` indicates that this is not checked",
-            "order": 2
+            "order": 2,
+            "scope": "resource"
           },
           "esbmc.propertyChecking.checkErrorLabel": {
             "type": "string",
             "markdownDescription": "Check that a given label is unreachable",
-            "order": 3
+            "order": 3,
+            "scope": "resource"
           }
         }
       },
@@ -604,49 +644,57 @@
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable checking of the base case",
-            "order": 0
+            "order": 0,
+            "scope": "resource"
           },
           "esbmc.kinduction.checkForwardCondition": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable checking of the forward condition",
-            "order": 1
+            "order": 1,
+            "scope": "resource"
           },
           "esbmc.kinduction.checkInductiveStep": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable checking of the inductive step",
-            "order": 2
+            "order": 2,
+            "scope": "resource"
           },
           "esbmc.kinduction.prove": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable proof by k-induction",
-            "order": 3
+            "order": 3,
+            "scope": "resource"
           },
           "esbmc.kinduction.parallelise": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable, running each k-Induction step on a separate process if  `#esbmc.kinduction.parallelise#` is true",
-            "order": 4
+            "order": 4,
+            "scope": "resource"
           },
           "esbmc.kinduction.kIncrement": {
             "type": "number",
             "default": 1,
             "markdownDescription": "Set the $k$ increment",
-            "order": 5
+            "order": 5,
+            "scope": "resource"
           },
           "esbmc.kinduction.iterationMax": {
             "type": "number",
             "default": 50,
             "markdownDescription": "Set the max number of iterations, a value of `-1` indicates `UINT_MAX`",
-            "order": 6
+            "order": 6,
+            "scope": "resource"
           },
           "esbmc.kinduction.bidirectional": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable bidirectional k-induction",
-            "order": 6
+            "order": 6,
+            "scope": "resource"
           }
         }
       },
@@ -659,31 +707,36 @@
             "type": "number",
             "default": -1,
             "markdownDescription": "Limit the number of number of context switches for each thread, `-1` implies no bound.",
-            "order": 0
+            "order": 0,
+            "scope": "resource"
           },
           "esbmc.concurrencyChecking.stateHashing": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable state hashing",
-            "order": 1
+            "order": 1,
+            "scope": "resource"
           },
           "esbmc.concurrencyChecking.partialOrderReduction": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Enable or disable partial order reduction",
-            "order": 2
+            "order": 2,
+            "scope": "resource"
           },
           "esbmc.concurrencyChecking.gotoMerging": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Enable or disable merging of GOTOs when restoring last path after a context switch",
-            "order": 3
+            "order": 3,
+            "scope": "resource"
           },
           "esbmc.concurrencyChecking.checkAllInterleavings": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Enable or disable merging of GOTOs when restoring last path after a context switch",
-            "order": 4
+            "order": 4,
+            "scope": "resource"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
           "esbmc.frontEnd.includeAfter": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Enable or disable system include path to search after system headers, `#esbmc.includePath#` must be set if enabled",
+            "markdownDescription": "Enable or disable system include path to search after system headers, `#esbmc.frontEnd.includePath#` must be set if enabled",
             "order": 2
           },
           "esbmc.frontEnd.defineMacros": {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -90,7 +90,7 @@ export async function run (overides?: Configuration, commentFlags?: string, docu
     flags = commentFlags
   } else {
     try {
-      flags = CONFIG_PARSER.parse(overides)
+      flags = CONFIG_PARSER.parse(overides, target.uri)
     } catch (error) {
       vscode.window.showErrorMessage(`ESBMC: ${error}`)
       return

--- a/src/commands/showFlags.ts
+++ b/src/commands/showFlags.ts
@@ -14,7 +14,9 @@ const CONFIG_PARSER = new ConfigurationParser()
 export async function showFlags (): Promise<void> {
   let flags: string
   try {
-    flags = CONFIG_PARSER.parse()
+    // Folder settings are read relative to a file, so report the flags for the
+    // one in front of the user.
+    flags = CONFIG_PARSER.parse(undefined, vscode.window.activeTextEditor?.document.uri)
   } catch (error) {
     vscode.window.showErrorMessage(`ESBMC: ${String(error)}`)
     return

--- a/src/parsers/configParser.ts
+++ b/src/parsers/configParser.ts
@@ -1,31 +1,15 @@
-import { workspace } from 'vscode'
+import { Uri, workspace } from 'vscode'
 import { sha1 } from 'object-hash'
 import { flatten } from './flatten'
 import { mergeConfigScopes } from './configScopes'
+import { SECTIONS } from './sections'
 
 import { Configuration } from '../@types/vscode.configuration'
 
-export const SECTIONS = [
-  'bmc',
-  'concurrencyChecking',
-  'frontEnd',
-  'kinduction',
-  'propertyChecking',
-  'solver',
-  'trace'
-]
+export { SECTIONS }
 
 export class ConfigurationParser {
   private _root: string = 'esbmc'
-  private _sections = [
-    'bmc',
-    'concurrencyChecking',
-    'frontEnd',
-    'kinduction',
-    'propertyChecking',
-    'solver',
-    'trace'
-  ]
 
   private cachedConfigHash: string
   private cachedOveridesHash: string
@@ -45,11 +29,14 @@ export class ConfigurationParser {
 
   /**
      * Parses ESBMC settings
+     *
+     * @param resource the file being verified. Folder settings only reach
+     * `inspect` when a resource identifies which folder to read them from.
      * @returns flags used to run ESBMC
      */
-  public parse (overides?: Configuration): string {
+  public parse (overides?: Configuration, resource?: Uri): string {
     overides = overides || {}
-    const workspaceConfig = workspace.getConfiguration(this._root)
+    const workspaceConfig = workspace.getConfiguration(this._root, resource)
     const hashConfig = sha1(workspaceConfig)
     const hashOverides = sha1(overides)
     // Check to see if incoming object hasn't changed and avoid redundant parsing
@@ -58,7 +45,7 @@ export class ConfigurationParser {
     }
     this.flags = []
     // Parse each section
-    for (const section of this._sections) {
+    for (const section of SECTIONS) {
       const sectionConfig = workspaceConfig.inspect<Configuration>(section)
       // User, then workspace, then folder: the narrowest scope the user set wins.
       let sectionChangedValues = mergeConfigScopes(

--- a/src/parsers/configParser.ts
+++ b/src/parsers/configParser.ts
@@ -1,6 +1,7 @@
 import { workspace } from 'vscode'
 import { sha1 } from 'object-hash'
 import { flatten } from './flatten'
+import { mergeConfigScopes } from './configScopes'
 
 import { Configuration } from '../@types/vscode.configuration'
 
@@ -59,7 +60,12 @@ export class ConfigurationParser {
     // Parse each section
     for (const section of this._sections) {
       const sectionConfig = workspaceConfig.inspect<Configuration>(section)
-      let sectionChangedValues = sectionConfig?.globalValue || {}
+      // User, then workspace, then folder: the narrowest scope the user set wins.
+      let sectionChangedValues = mergeConfigScopes(
+        sectionConfig?.globalValue,
+        sectionConfig?.workspaceValue,
+        sectionConfig?.workspaceFolderValue
+      )
       // If overrides are present that arent in the updated values, add them
       this.overides = overides
       if (section in this.overides) {

--- a/src/parsers/configScopes.ts
+++ b/src/parsers/configScopes.ts
@@ -1,0 +1,30 @@
+import { Configuration } from '../@types/vscode.configuration'
+
+function isPlainObject (value: unknown): value is Configuration {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Combines the scopes VS Code reports for a settings section.
+ *
+ * `inspect` reports each scope separately and only returns values that were
+ * explicitly set, so reading `globalValue` alone silently ignores everything
+ * in a workspace or folder `settings.json`. Later scopes win, and nested
+ * groups merge key by key rather than wholesale, so a workspace setting one
+ * property does not discard a user setting on another.
+ */
+export function mergeConfigScopes (...scopes: Array<Configuration | undefined>): Configuration {
+  const merged: Configuration = {}
+  for (const scope of scopes) {
+    if (!isPlainObject(scope)) {
+      continue
+    }
+    for (const [key, value] of Object.entries(scope)) {
+      const existing = merged[key]
+      merged[key] = isPlainObject(existing) && isPlainObject(value)
+        ? { ...existing, ...value }
+        : value
+    }
+  }
+  return merged
+}

--- a/src/parsers/sections.ts
+++ b/src/parsers/sections.ts
@@ -1,0 +1,10 @@
+/** The settings groups that map to ESBMC flags, in the order they are parsed. */
+export const SECTIONS = [
+  'bmc',
+  'concurrencyChecking',
+  'frontEnd',
+  'kinduction',
+  'propertyChecking',
+  'solver',
+  'trace'
+]

--- a/src/test/package/SettingsLinks.test.ts
+++ b/src/test/package/SettingsLinks.test.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const ROOT = path.resolve(__dirname, '..', '..', '..')
+const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'))
+
+const settings = manifest.contributes.configuration.flatMap(
+  (group: any) => Object.entries<any>(group.properties)
+)
+const ids = new Set(settings.map(([id]: [string, any]) => id))
+
+/** Links appear in the setting description and in each enum value description. */
+function descriptions (setting: any): string[] {
+  return [setting.markdownDescription, ...(setting.markdownEnumDescriptions ?? [])]
+    .filter((text: unknown): text is string => typeof text === 'string')
+}
+
+// `#some.setting#` renders as a link to that setting, but only if it names a
+// real one; otherwise VS Code shows the raw text with the hashes.
+describe('settings links', () => {
+  it('has settings to check', () => {
+    assert.ok(ids.size > 0)
+  })
+
+  it('only links settings that exist', () => {
+    for (const [id, setting] of settings) {
+      for (const [, target] of descriptions(setting).join('\n').matchAll(/`#([\w.]+)#`/g)) {
+        assert.ok(ids.has(target), `${id} links #${target}#, which is not a setting`)
+      }
+    }
+  })
+
+  it('links by full id, not a bare section name', () => {
+    for (const [id, setting] of settings) {
+      for (const [, target] of descriptions(setting).join('\n').matchAll(/`#([\w.]+)#`/g)) {
+        assert.ok(
+          target.split('.').length >= 3,
+          `${id} links #${target}#, which is missing its configuration section`
+        )
+      }
+    }
+  })
+})

--- a/src/test/package/SettingsScopes.test.ts
+++ b/src/test/package/SettingsScopes.test.ts
@@ -1,0 +1,36 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as path from 'path'
+import { SECTIONS } from '../../parsers/sections'
+
+const ROOT = path.resolve(__dirname, '..', '..', '..')
+const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'))
+
+const settings: Array<[string, any]> = manifest.contributes.configuration.flatMap(
+  (group: any) => Object.entries<any>(group.properties)
+)
+
+function section (id: string): string {
+  return id.split('.')[1]
+}
+
+// A `window`-scoped setting never yields a workspaceFolderValue from inspect(),
+// whatever resource is passed, so merging the folder scope in the parser would
+// be reading a value VS Code cannot produce.
+describe('settings scopes', () => {
+  it('has the sections the parser reads', () => {
+    const covered = new Set(settings.map(([id]) => section(id)))
+    for (const parsed of SECTIONS) {
+      assert.ok(covered.has(parsed), `no setting contributed for section ${parsed}`)
+    }
+  })
+
+  it('declares every parsed setting at resource scope', () => {
+    for (const [id, setting] of settings) {
+      if (!SECTIONS.includes(section(id))) {
+        continue
+      }
+      assert.strictEqual(setting.scope, 'resource', `${id} is not folder-settable`)
+    }
+  })
+})

--- a/src/test/parsers/ConfigScopes.test.ts
+++ b/src/test/parsers/ConfigScopes.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert'
+import { mergeConfigScopes } from '../../parsers/configScopes'
+
+describe('mergeConfigScopes', () => {
+  it('returns nothing when no scope sets anything', () => {
+    assert.deepStrictEqual(mergeConfigScopes(undefined, undefined, undefined), {})
+  })
+
+  // The bug this fixes: only the user scope was read, so a per-project
+  // settings.json was silently inert.
+  it('includes a value set only in the workspace', () => {
+    assert.deepStrictEqual(
+      mergeConfigScopes({ unwind: 5 }, { mainFunction: 'go' }, undefined),
+      { unwind: 5, mainFunction: 'go' }
+    )
+  })
+
+  it('lets the narrower scope win', () => {
+    assert.deepStrictEqual(mergeConfigScopes({ unwind: 5 }, { unwind: 10 }, undefined), { unwind: 10 })
+    assert.deepStrictEqual(mergeConfigScopes({ unwind: 5 }, { unwind: 10 }, { unwind: 20 }), { unwind: 20 })
+  })
+
+  // A workspace setting one property must not discard a user setting on
+  // another, which a wholesale replace would do.
+  it('merges nested groups key by key', () => {
+    assert.deepStrictEqual(
+      mergeConfigScopes({ properties: { nan: true } }, { properties: { memoryLeak: true } }, undefined),
+      { properties: { nan: true, memoryLeak: true } }
+    )
+  })
+
+  it('lets the narrower scope win inside a nested group', () => {
+    assert.deepStrictEqual(
+      mergeConfigScopes({ properties: { nan: true } }, { properties: { nan: false } }, undefined),
+      { properties: { nan: false } }
+    )
+  })
+
+  it('replaces rather than merges when a scope changes the type', () => {
+    assert.deepStrictEqual(mergeConfigScopes({ a: { b: 1 } }, { a: 5 }, undefined), { a: 5 })
+    assert.deepStrictEqual(mergeConfigScopes({ a: 5 }, { a: { b: 1 } }, undefined), { a: { b: 1 } })
+  })
+
+  it('ignores a scope that is not an object', () => {
+    assert.deepStrictEqual(mergeConfigScopes({ unwind: 5 }, undefined, undefined), { unwind: 5 })
+  })
+})

--- a/src/test/parsers/ConfigScopesThroughParser.test.ts
+++ b/src/test/parsers/ConfigScopesThroughParser.test.ts
@@ -1,0 +1,74 @@
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { Configuration } from '../../@types/vscode.configuration'
+import { ConfigurationParser } from '../../parsers/configParser'
+import { SECTIONS } from '../../parsers/sections'
+
+const SETTINGS_ROOT = 'esbmc'
+
+async function clear (target: vscode.ConfigurationTarget) {
+  const config = vscode.workspace.getConfiguration(SETTINGS_ROOT)
+  for (const section of SECTIONS) {
+    const inspected = config.inspect<Configuration>(section)
+    const scope = target === vscode.ConfigurationTarget.Workspace
+      ? inspected?.workspaceValue
+      : inspected?.globalValue
+    for (const key of Object.keys(scope ?? {})) {
+      await config.update(`${section}.${key}`, undefined, target)
+    }
+  }
+}
+
+// mergeConfigScopes is unit tested on hand-built scope objects, which says
+// nothing about whether inspect() ever reports a workspace value. This drives
+// the parser against settings VS Code actually stored.
+describe('ConfigurationParser across settings scopes', function () {
+  this.timeout(30000)
+
+  const folder = vscode.workspace.workspaceFolders?.[0]
+
+  before(function () {
+    if (folder === undefined) {
+      // Workspace settings cannot be written without a folder open, and the
+      // point of the test is that they are read.
+      this.skip()
+    }
+  })
+
+  beforeEach(async () => {
+    await clear(vscode.ConfigurationTarget.Workspace)
+    await clear(vscode.ConfigurationTarget.Global)
+  })
+
+  after(async () => {
+    await clear(vscode.ConfigurationTarget.Workspace)
+    await clear(vscode.ConfigurationTarget.Global)
+  })
+
+  it('emits a flag set only in the workspace', async () => {
+    const config = vscode.workspace.getConfiguration(SETTINGS_ROOT)
+    await config.update('bmc.unwind', 7, vscode.ConfigurationTarget.Workspace)
+
+    const flags = new ConfigurationParser().parse(undefined, folder?.uri)
+    assert.strictEqual(flags, '--unwind 7')
+  })
+
+  it('lets a workspace setting win over the same user setting', async () => {
+    const config = vscode.workspace.getConfiguration(SETTINGS_ROOT)
+    await config.update('bmc.unwind', 3, vscode.ConfigurationTarget.Global)
+    await config.update('bmc.unwind', 9, vscode.ConfigurationTarget.Workspace)
+
+    const flags = new ConfigurationParser().parse(undefined, folder?.uri)
+    assert.strictEqual(flags, '--unwind 9')
+  })
+
+  it('keeps a user setting the workspace does not touch', async () => {
+    const config = vscode.workspace.getConfiguration(SETTINGS_ROOT)
+    await config.update('bmc.unwind', 4, vscode.ConfigurationTarget.Global)
+    await config.update('bmc.mainFunction', 'go', vscode.ConfigurationTarget.Workspace)
+
+    const flags = new ConfigurationParser().parse(undefined, folder?.uri)
+    assert.ok(flags.includes('--unwind 4'), `user setting lost: ${flags}`)
+    assert.ok(flags.includes('--function go'), `workspace setting lost: ${flags}`)
+  })
+})

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,8 +1,14 @@
+import * as fs from 'fs'
+import * as os from 'os'
 import * as path from 'path'
 
 import { runTests } from '@vscode/test-electron'
 
 async function main () {
+  // Workspace-scoped settings cannot be written unless a folder is open, and
+  // ConfigurationTarget.Workspace writes .vscode/settings.json into it, so the
+  // folder has to be a throwaway rather than the checkout.
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-esbmc-tests-'))
   try {
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
@@ -13,10 +19,16 @@ async function main () {
     const extensionTestsPath = path.resolve(__dirname, './suite/index')
 
     // Download VS Code, unzip it and run the integration test
-    await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: ['--disable-extensions'] })
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [workspace, '--disable-extensions']
+    })
   } catch (err) {
     console.error('Failed to run tests')
     process.exit(1)
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true })
   }
 }
 


### PR DESCRIPTION
Two defects I found while reviewing earlier work in this stack and recorded but never fixed.

**Workspace settings were silently ignored.** `ConfigurationParser.parse` read `inspect(section)?.globalValue` and nothing else, so anything set in a workspace or folder `settings.json` had no effect — a per-project unwind bound, solver choice or property set simply did nothing, with no warning. That also means #17 only half-delivered its "configurable unwind bound": the setting existed but was inert outside User scope, which I flagged on #26 at the time.

All three scopes are now merged with the narrowest winning. Nested groups (`properties`, `options`) merge key by key rather than wholesale, so a workspace enabling one property does not discard a user setting on another — that case has its own test, because a shallow merge looks correct until someone hits it.

**A settings link named a setting that does not exist.** `esbmc.frontEnd.includeAfter` linked `` `#esbmc.includePath#` ``; the real id is `esbmc.frontEnd.includePath`. VS Code renders an unresolvable link as raw text, hashes and all.

There is now a test holding every `#setting#` link to a real id. Writing it caught a gap in my own first version: the link I added in #23 lives in `markdownEnumDescriptions`, not `markdownDescription`, so the check missed it entirely and the mutation survived. It scans both now.

139 tests passing headlessly; 5 mutations, all caught.

Stacked on #42.