### PR TITLE
Stop a custom solver path from discarding the chosen solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Fixed
 
+- Choosing a solver had no effect if a custom solver path was also set: the
+  guard meant to restrict that path to `custom` was written `x || true`, so it
+  was always true and the chosen solver flag was dropped. Selecting `custom`
+  also emitted only `--smtlib-solver-prog`, which names the binary without
+  selecting it, so ESBMC quietly used its own default; and selecting `custom`
+  with no path emitted `--custom`, which is not an ESBMC flag.
+
 - Settings set in a workspace or folder `settings.json` were silently ignored:
   the flag parser read only the user scope, so a per-project unwind bound or
   solver choice did nothing. All three scopes are now read, narrowest winning.

--- a/src/parsers/configParser.ts
+++ b/src/parsers/configParser.ts
@@ -2,6 +2,7 @@ import { workspace } from 'vscode'
 import { sha1 } from 'object-hash'
 import { flatten } from './flatten'
 import { mergeConfigScopes } from './configScopes'
+import { quoteShellArg } from '../utils/commands'
 
 import { Configuration } from '../@types/vscode.configuration'
 
@@ -252,8 +253,9 @@ export class ConfigurationParser {
     dependentKey: string, dependentValue: any,
     dependentDefaultValue: any, secondaryFlag: string,
     prereqCondition?: boolean): void {
-    // Set prereqCondition is undefined
-    prereqCondition = prereqCondition || true
+    // `|| true` here made the caller-supplied guard dead, which silently
+    // discarded the solver choice whenever a custom solver path was also set.
+    prereqCondition = prereqCondition ?? true
     // Dependent flag is added if the dependentKey is not in the section config
     if (prereqKey in this.flatSectionConfig && !(dependentKey in this.flatSectionConfig) && prereqCondition) {
       this.addGenericFlag(prereqValue, prereqDefaultValue, primaryFlag)
@@ -618,21 +620,20 @@ export class ConfigurationParser {
   private parseSolver (key: string, value:any): void {
     switch (key) {
       case 'smtSolver': {
-        const dependentKey = 'customSmtSolverPath'
-        const dependentDefaultValue = ''
-        const dependentValue = dependentKey in this.flatSectionConfig
-          ? this.flatSectionConfig[dependentKey]
-          : dependentDefaultValue
-        this.addDependentFlags(
-          'smtSolver',
-          value,
-          'boolector',
-                    `--${value}`,
-                    dependentKey,
-                    dependentValue,
-                    dependentDefaultValue,
-                    `--smtlib-solver-prog ${dependentValue}`,
-                    value === 'custom'
+        if (value !== 'custom') {
+          // A custom solver path left over from an earlier choice must not
+          // override the solver the user actually picked.
+          this.addStringFlag(value, 'boolector', `--${value}`)
+          break
+        }
+        const customPath = this.flatSectionConfig.customSmtSolverPath
+        // --smtlib-solver-prog only names the binary. ESBMC never selects the
+        // SMT-LIB backend implicitly, so without --smtlib it silently uses its
+        // own default solver instead.
+        this.addFlag(
+          typeof customPath === 'string' && customPath !== '',
+          `--smtlib --smtlib-solver-prog ${quoteShellArg(String(customPath))}`,
+          'Set esbmc.solver.customSmtSolverPath when esbmc.solver.smtSolver is custom'
         )
         break
       }

--- a/src/test/parsers/ConfigParser.test.ts
+++ b/src/test/parsers/ConfigParser.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert'
 import * as vscode from 'vscode'
 import { Configuration } from '../../@types/vscode.configuration'
 import { ConfigurationParser, SECTIONS } from '../../parsers/configParser'
+import { quoteShellArg } from '../../utils/commands'
 
 const SETTINGS_ROOT = 'esbmc'
 
@@ -689,9 +690,17 @@ describe('ConfigurationParser Test Suite', () => {
         expected: '--bitwuzla'
       },
       {
+        // --smtlib-solver-prog only names the binary; without --smtlib ESBMC
+        // never selects the SMT-LIB backend and quietly uses its own default.
         settings: ['solver.smtSolver', 'solver.customSmtSolverPath'],
         values: ['custom', VALID_PATH],
-        expected: `--smtlib-solver-prog ${VALID_PATH}`
+        expected: `--smtlib --smtlib-solver-prog ${quoteShellArg(VALID_PATH)}`
+      },
+      {
+        // A leftover custom path must not discard the solver actually chosen.
+        settings: ['solver.smtSolver', 'solver.customSmtSolverPath'],
+        values: ['z3', VALID_PATH],
+        expected: '--z3'
       },
       {
         settings: ['solver.smtLibFormat'],
@@ -775,6 +784,21 @@ describe('ConfigurationParser Test Suite', () => {
     validTests.forEach(({ settings, values, expected }) => {
       it(`Checking settings ${JSON.stringify(settings)} with respective valid values ${JSON.stringify(values)}`, async function () {
         await assertCorrectFlagParse(settings, values, expected)
+      })
+    })
+
+    const invalidTests = [
+      {
+        // Without a path there is nothing to run, and the old behaviour passed
+        // ESBMC a `--custom` flag it does not have.
+        settings: ['solver.smtSolver'],
+        values: ['custom']
+      }
+    ]
+
+    invalidTests.forEach(({ settings, values }) => {
+      it(`Checking settings ${JSON.stringify(settings)} with respective invalid values ${JSON.stringify(values)} throws exception`, async function () {
+        await assertIncorrectFlagParseThrows(settings, values)
       })
     })
   })


### PR DESCRIPTION
Three defects, all downstream of one line. `addDependentFlags` contained:

```ts
prereqCondition = prereqCondition || true
```

which is always `true`, so the guard the caller passes (`value === 'custom'`) never applied. I reproduced all three in isolation before touching anything:

| Setting | Emitted | Should emit |
| --- | --- | --- |
| `smtSolver: z3` **+ a custom path also set** | `--smtlib-solver-prog /my/solver` | `--z3` |
| `smtSolver: custom` + path | `--smtlib-solver-prog /my/solver` | `--smtlib --smtlib-solver-prog …` |
| `smtSolver: custom`, no path | `--custom` | an actionable error |

The first is the serious one: **picking a solver did nothing** if a custom path was left over from an earlier choice — no warning, and the wrong solver runs.

The second matters because `--smtlib-solver-prog` only names the binary. I confirmed against ESBMC's `solve.cpp` that `pick_default_solver()` explicitly skips `smtlib`, so without `--smtlib` the external solver is never selected and ESBMC quietly uses its own default. I corrected the *description* of this setting back in #23 but not the behaviour, so the docs have been right and the code wrong since then.

The third passed ESBMC a `--custom` flag that does not exist; it now raises the same kind of actionable error the other invalid settings do. The path is shell-quoted as well, consistent with #26.

The harness tests are updated: the existing expectation encoded the buggy output, and there are new cases for the leftover-path and missing-path situations. The expectation is built with `quoteShellArg` rather than hard-coded quotes, because the harness runs on Windows too and the quoting differs.

These tests need the VS Code harness, so CI verifies them rather than my machine.

Stacked on #43.