### PR TITLE
Send a chosen setting even when it matches the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Fixed
 
+- Choosing a value that happened to equal the manifest default was silently
+  dropped instead of sent to ESBMC, whose own defaults differ: `boolector`
+  became bitwuzla, and `i386-linux` became the host architecture on macOS and
+  Windows. Explicit choices are now always passed.
+
 - Choosing a solver had no effect if a custom solver path was also set: the
   guard meant to restrict that path to `custom` was written `x || true`, so it
   was always true and the chosen solver flag was dropped. Selecting `custom`

--- a/src/parsers/configParser.ts
+++ b/src/parsers/configParser.ts
@@ -151,6 +151,21 @@ export class ConfigurationParser {
   }
 
   /**
+     * Adds a flag for a setting the user chose explicitly.
+     *
+     * `inspect` only reports settings that were actually written, so a value
+     * present here was chosen even when it equals the manifest default. The
+     * default-suppressing helpers drop those, which silently defers to
+     * ESBMC's own default — and that is bitwuzla rather than boolector, and
+     * the host architecture rather than i386-linux.
+     *
+     * @param flag the flag to be added
+     */
+  private addExplicitFlag (flag: string): void {
+    this.flags.push(flag)
+  }
+
+  /**
      * Adds numeric like ESBMC flag to the set of flags
      *
      * @param value the value of the setting
@@ -508,11 +523,11 @@ export class ConfigurationParser {
         break
       }
       case 'wordLength': {
-        this.addNumericFlag(value, 64, `--${value}`)
+        this.addExplicitFlag(`--${value}`)
         break
       }
       case 'architecture': {
-        this.addStringFlag(value, 'i386-linux', `--${value}`)
+        this.addExplicitFlag(`--${value}`)
         break
       }
       case 'endianness': {
@@ -623,7 +638,7 @@ export class ConfigurationParser {
         if (value !== 'custom') {
           // A custom solver path left over from an earlier choice must not
           // override the solver the user actually picked.
-          this.addStringFlag(value, 'boolector', `--${value}`)
+          this.addExplicitFlag(`--${value}`)
           break
         }
         const customPath = this.flatSectionConfig.customSmtSolverPath

--- a/src/test/parsers/ConfigParser.test.ts
+++ b/src/test/parsers/ConfigParser.test.ts
@@ -423,6 +423,13 @@ describe('ConfigurationParser Test Suite', () => {
         expected: '--32'
       },
       {
+        // Choosing the default explicitly must still reach ESBMC, whose own
+        // default need not match the manifest's.
+        settings: ['frontEnd.wordLength'],
+        values: [64],
+        expected: '--64'
+      },
+      {
         settings: ['frontEnd.architecture'],
         values: ['i386-macos'],
         expected: '--i386-macos'
@@ -436,6 +443,13 @@ describe('ConfigurationParser Test Suite', () => {
         settings: ['frontEnd.architecture'],
         values: ['i386-win32'],
         expected: '--i386-win32'
+      },
+      {
+        // ESBMC defaults to the host architecture, so on macOS or Windows an
+        // unsent --i386-linux silently gives the user a different one.
+        settings: ['frontEnd.architecture'],
+        values: ['i386-linux'],
+        expected: '--i386-linux'
       },
       {
         settings: ['frontEnd.endianness'],
@@ -688,6 +702,13 @@ describe('ConfigurationParser Test Suite', () => {
         settings: ['solver.smtSolver'],
         values: ['bitwuzla'],
         expected: '--bitwuzla'
+      },
+      {
+        // ESBMC picks bitwuzla when no solver is named, so choosing boolector
+        // has to be sent or it is quietly ignored.
+        settings: ['solver.smtSolver'],
+        values: ['boolector'],
+        expected: '--boolector'
       },
       {
         // --smtlib-solver-prog only names the binary; without --smtlib ESBMC


### PR DESCRIPTION
The last of the findings I recorded during earlier reviews on this stack and never fixed.

`inspect()` only reports settings the user actually wrote, so a value present in the parsed config was chosen deliberately. Suppressing it because it equals the *manifest* default hands the decision back to ESBMC — whose defaults are not the same:

| Setting chosen | Was sent | ESBMC actually used |
| --- | --- | --- |
| `smtSolver: boolector` | nothing | bitwuzla |
| `architecture: i386-linux` on macOS | nothing | i386-macos |
| `architecture: i386-linux` on Windows | nothing | i386-win32 |

Both confirmed at source: `pick_default_solver()` in `solve.cpp` skips the first three entries of `all_solvers` and lands on bitwuzla, and the architecture defaults in `options.cpp` are `#ifdef`-guarded per host. The architecture case became user-visible with #33, which made macOS and Windows first-class.

The existing tests document the gap without meaning to: they cover `16`, `32`, `i386-macos`, `ppc-macos`, `i386-win32` — every value **except** the defaults, because those produced no output to assert on. Those three cases are now added.

Sentinel values (`auto`, `none`, `verify`) still emit nothing, because they have no flag of their own. This only changes settings whose default is a real ESBMC flag.

Stacked on #44.