### PR TITLE
Supersede a pull request's previous CI run

### DIFF
--- a/.github/workflows/on-pr-master.yml
+++ b/.github/workflows/on-pr-master.yml
@@ -10,6 +10,13 @@ env:
   # breaking one would break packaging with no change here.
   VSCE: '@vscode/vsce@3.9.2'
 
+# Pushing again supersedes the previous run rather than queueing beside it.
+# With a 3-OS matrix plus packaging, a stack of branches otherwise leaves
+# dozens of obsolete jobs holding runners.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,12 @@ env:
   VSCE: '@vscode/vsce@3.9.2'
   OVSX: 'ovsx@1.1.1'
 
+# A second tag must not cancel a publish that is mid-flight: the VSIX may
+# already be on one registry and not the other.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Changed
 
+- Pushing to a pull request now supersedes its previous CI run instead of
+  queueing beside it. Publishing deliberately does not: a second tag must not
+  cancel a release that may already have reached one registry and not the other.
+
 - Dropped `glob` from the test runner, which walks its own directory in a
   dozen lines. Its callback API was removed in v9 and each major since raises
   the Node floor. A test now guards the walk, because a discovery bug makes the


### PR DESCRIPTION
Observed while re-integrating the stack: pushing to all thirteen branches queued roughly **fifty jobs** — three OSes plus a packaging job per PR — and every superseded run kept holding runners rather than being cancelled. Waits went past forty minutes, which delays exactly the results anyone is waiting on.

A concurrency group per workflow-and-ref fixes it: a new push cancels the run it replaces.

`publish.yml` deliberately sets `cancel-in-progress: false`. A release is not idempotent — by the time a second tag arrives the VSIX may already be on the Marketplace and not yet on Open VSX, and cancelling there leaves the two registries disagreeing about what the current version is. Queueing is the right behaviour for that one.

Both files parse as valid YAML with the expected `concurrency` and `jobs` keys.

Stacked on #45.